### PR TITLE
refactor: replace `execa` w/ `ezspawn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@antfu/ni": "^0.21.12",
+    "@jsdevtools/ez-spawn": "^3.0.4",
     "cli-progress": "^3.12.0",
     "deepmerge": "^4.3.1",
     "detect-indent": "^7.0.1",
-    "execa": "^8.0.1",
     "picocolors": "^1.0.0",
     "prompts": "^2.4.2",
     "ufo": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@antfu/ni':
         specifier: ^0.21.12
         version: 0.21.12
+      '@jsdevtools/ez-spawn':
+        specifier: ^3.0.4
+        version: 3.0.4
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -20,9 +23,6 @@ importers:
       detect-indent:
         specifier: ^7.0.1
         version: 7.0.1
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
       picocolors:
         specifier: ^1.0.0
         version: 1.0.0

--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { async as ezspawnAsync } from '@jsdevtools/ez-spawn'
+import { async as ezspawn } from '@jsdevtools/ez-spawn'
 import c from 'picocolors'
 import prompts from 'prompts'
 import { type Agent, getCommand } from '@antfu/ni'
@@ -118,7 +118,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
   let pnpmStdout
 
   try {
-    pnpmStdout = (await ezspawnAsync('pnpm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })).stdout
+    pnpmStdout = (await ezspawn('pnpm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })).stdout
   }
   catch (error) {
     return []
@@ -152,7 +152,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
 }
 
 async function loadGlobalNpmPackage(options: CheckOptions): Promise<GlobalPackageMeta> {
-  const { stdout } = await ezspawnAsync('npm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })
+  const { stdout } = await ezspawn('npm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })
   const npmOut = JSON.parse(stdout) as NpmOut
   const filter = createDependenciesFilter(options.include, options.exclude)
 
@@ -182,5 +182,5 @@ async function installPkg(pkg: GlobalPackageMeta) {
   const dependencies = dumpDependencies(changes, 'dependencies')
   const updateArgs = Object.entries(dependencies).map(([name, version]) => `${name}@${version}`)
   const installCommand = getCommand(pkg.agent, 'global', [...updateArgs])
-  await ezspawnAsync(installCommand, { stdio: 'inherit' })
+  await ezspawn(installCommand, { stdio: 'inherit' })
 }

--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { execa, execaCommand } from 'execa'
+import { async as ezspawnAsync } from '@jsdevtools/ez-spawn'
 import c from 'picocolors'
 import prompts from 'prompts'
 import { type Agent, getCommand } from '@antfu/ni'
@@ -118,7 +118,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
   let pnpmStdout
 
   try {
-    pnpmStdout = (await execa('pnpm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })).stdout
+    pnpmStdout = (await ezspawnAsync('pnpm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })).stdout
   }
   catch (error) {
     return []
@@ -152,7 +152,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
 }
 
 async function loadGlobalNpmPackage(options: CheckOptions): Promise<GlobalPackageMeta> {
-  const { stdout } = await execa('npm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })
+  const { stdout } = await ezspawnAsync('npm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })
   const npmOut = JSON.parse(stdout) as NpmOut
   const filter = createDependenciesFilter(options.include, options.exclude)
 
@@ -182,5 +182,5 @@ async function installPkg(pkg: GlobalPackageMeta) {
   const dependencies = dumpDependencies(changes, 'dependencies')
   const updateArgs = Object.entries(dependencies).map(([name, version]) => `${name}@${version}`)
   const installCommand = getCommand(pkg.agent, 'global', [...updateArgs])
-  await execaCommand(installCommand, { stdio: 'inherit' })
+  await ezspawnAsync(installCommand, { stdio: 'inherit' })
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,11 +1,11 @@
 import path from 'node:path'
 import { expect, it } from 'vitest'
-import { execa } from 'execa'
+import { async as ezspawnAsync } from '@jsdevtools/ez-spawn'
 
 it('taze cli should just works', async () => {
   const binPath = path.resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await execa(process.execPath, [binPath], { stdio: 'pipe' })
+  const proc = await ezspawnAsync(process.execPath, [binPath], { stdio: 'pipe' })
 
   expect(proc.stderr).toBe('')
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,11 +1,11 @@
 import path from 'node:path'
 import { expect, it } from 'vitest'
-import { async as ezspawnAsync } from '@jsdevtools/ez-spawn'
+import { async as ezspawn } from '@jsdevtools/ez-spawn'
 
 it('taze cli should just works', async () => {
   const binPath = path.resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await ezspawnAsync(process.execPath, [binPath], { stdio: 'pipe' })
+  const proc = await ezspawn(process.execPath, [binPath], { stdio: 'pipe' })
 
   expect(proc.stderr).toBe('')
 })


### PR DESCRIPTION
I first encountered the package `@jsdevtools/ez-spawn` through [`bumpp`](https://github.com/antfu-collective/bumpp/blob/3e90d138c6e2fb7e7e1e5344fd359543567bd658/package.json#L62), which uses `exspawn` under the hood.

Though no longer being actively maintained, `ezspawn` already fulfills almost every use case and doesn't suffer from breaking bugs.

`@jsdevtools/ez-spawn` has fewer dependencies than `execa` and takes up only 47% of the disk space (the installation size of `@jsdevtools/ez-spawn` is [142 KiB](https://pkg-size.dev/@jsdevtools%2Fez-spawn) compared to `execa` at [301 KiB](https://pkg-size.dev/execa)). Moreover, its usage is extremely straightforward. Unlike `execa`, which has separated `execa` and `execCommand`, `ezspawn`'s single method can perform both functions.
