### PR TITLE
feat: new mode `next`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ import type { CheckOptions, CommonOptions, UsageOptions } from './types'
 
 export const LOG_LEVELS = ['debug', 'info', 'warn', 'error', 'silent'] as const
 
-export const MODE_CHOICES = ['default', 'major', 'minor', 'patch', 'latest', 'newest'] as const
+export const MODE_CHOICES = ['default', 'major', 'minor', 'patch', 'latest', 'newest', 'next'] as const
 
 export const DEFAULT_COMMON_OPTIONS: CommonOptions = {
   cwd: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
+import type { MODE_CHOICES } from './constants'
 import type { SortOption } from './utils/sort'
 
-export type RangeMode = 'default' | 'major' | 'minor' | 'patch' | 'latest' | 'newest'
+export type RangeMode = typeof MODE_CHOICES[number]
 export type PackageMode = Omit<RangeMode, 'default'> | 'ignore'
 export type DepType = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies' | 'packageManager' | 'pnpm.overrides' | 'resolutions' | 'overrides'
 

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -27,7 +27,7 @@ export function getVersionRangePrefix(v: string) {
   return null
 }
 
-export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest' | 'newest'>) {
+export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest' | 'newest' | 'next'>) {
   if (!semver.validRange(version))
     return null
 
@@ -71,6 +71,9 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
   }
   else if (mode === 'newest') {
     version = versions[versions.length - 1]
+  }
+  else if (mode === 'next') {
+    version = tags.next
   }
   else if (mode === 'default' && (current === '*' || current.trim() === '')) {
     return

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -100,4 +100,18 @@ it('getMaxSatisfying', async () => {
     latest: '1.0.0-next.4',
     next: '1.0.0-next.2',
   }))
+
+  // should return the next tag version on next mode
+  // a good test case for this is eslint-plugin-react-hooks
+  expect('5.1.0-beta-4508873393-20240430').toBe(getMaxSatisfying([
+    '4.6.1',
+    '4.6.2',
+    '5.1.0-beta-4508873393-20240430',
+    '0.0.0-experimental-4508873393-20240430',
+  ], '^1.0.0-next.1', 'next', {
+    latest: '4.6.2',
+    next: '5.1.0-beta-4508873393-20240430',
+    rc: '4.2.1-rc.3',
+    experimental: '0.0.0-experimental-4508873393-20240430',
+  }))
 }, 10_000)


### PR DESCRIPTION
Prior to #37, `taze newest` would specifically target the `next` tag of a package. #37 altered this to target the most recently published version of the package.

I appreciate the modification introduced by #37 (it does make sense), but occasionally, I need to bump the `next` tag of a package rather than the most recently published version. `eslint-plugin-react-hooks` would be an example of the case:

<img width="781" alt="image" src="https://github.com/antfu-collective/taze/assets/40715044/61bf8ab3-5130-455a-8ac9-28283b010f46">

So I introduce a new mode `next` that brings the old behavior back.