### PR TITLE
fix: sync navigation with rendering in interactive mode

### DIFF
--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -18,12 +18,11 @@ export function renderChange(
   interactive?: InteractiveContext,
   grouped = false,
 ) {
-  const update = change.update && (!interactive || change.interactiveChecked)
-  const isSelected = interactive && interactive.isSelected(change)
+  const update = change.update && (!interactive || interactive.isChecked(change))
   const pre = interactive
     ? [
-        isSelected ? FIG_POINTER : FIG_NO_POINTER,
-        change.interactiveChecked ? FIG_CHECK : FIG_UNCHECK,
+        interactive.isSelected(change) ? FIG_POINTER : FIG_NO_POINTER,
+        interactive.isChecked(change) ? FIG_CHECK : FIG_UNCHECK,
       ].join('')
     : ' '
 
@@ -70,7 +69,7 @@ export function renderChanges(
   if (changes.length) {
     const diffCounts: Record<string, number> = {}
     changes
-      .filter(i => !interactive || i.interactiveChecked)
+      .filter(dep => !interactive || interactive.isChecked(dep))
       .forEach(({ diff }) => {
         if (!diff)
           return

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,6 @@ export interface ResolvedDepChange extends RawDep {
   diff: DiffType
   pkgData: PackageData
   resolveError?: Error | string | null
-  interactiveChecked?: boolean
   aliasName?: string
 }
 
@@ -149,12 +148,19 @@ export interface PackageMeta {
    * Resolved dependencies
    */
   resolved: ResolvedDepChange[]
-  interactiveChecked?: boolean
 }
 
 export type DependencyFilter = (dep: RawDep) => boolean | Promise<boolean>
 export type DependencyResolvedCallback = (packageName: string | null, depName: string, progress: number, total: number) => void
 
 export interface InteractiveContext {
+  /**
+   * Whether the dependency is selected with cursor in the interactive list.
+   */
   isSelected: (dep: RawDep) => boolean
+
+  /**
+   * Whether the dependency is marked as checked in the interactive list.
+   */
+  isChecked: (dep: RawDep) => boolean
 }


### PR DESCRIPTION
### Description

This PR fixes the issue when navigation in the list of dependencies in the interactive mode is not synced with actual rendered list on the screen when navigating.

Changes:
- Resolved packages dependencies are sorted each time version is changed by renderer created with `createVersionSelectRender`.
- `interactiveChecked` property removed from `ResolvedDepChange`, because related functionality was refactored to use `Set` instead, which makes code more readable and isolates the interactivity-related functionality.
- `interactiveChecked` property removed from `PackageMeta` since it's not used anywhere.

### Linked Issues

Fixes #132.

### Additional Context

The issue fixed in this PR may still arise later, because rendered dependencies are implicitly kept in sync with actual rendering in `renderChanges` function. For now I didn't come up with a small better solution.