### PR TITLE
refactor: replace `ezsapawn` w/ `tinyexec`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@antfu/ni": "^0.22.1",
-    "@jsdevtools/ez-spawn": "^3.0.4",
     "js-yaml": "^4.1.0",
     "npm-registry-fetch": "^17.1.0",
     "ofetch": "^1.3.4",
+    "tinyexec": "^0.2.0",
     "unconfig": "^0.5.5",
     "yargs": "^17.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "js-yaml": "^4.1.0",
     "npm-registry-fetch": "^17.1.0",
     "ofetch": "^1.3.4",
-    "tinyexec": "^0.2.0",
+    "tinyexec": "^0.3.0",
     "unconfig": "^0.5.5",
     "yargs": "^17.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@antfu/ni':
         specifier: ^0.22.1
         version: 0.22.1
-      '@jsdevtools/ez-spawn':
-        specifier: ^3.0.4
-        version: 3.0.4
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -23,6 +20,9 @@ importers:
       ofetch:
         specifier: ^1.3.4
         version: 1.3.4
+      tinyexec:
+        specifier: ^0.2.0
+        version: 0.2.0
       unconfig:
         specifier: ^0.5.5
         version: 0.5.5
@@ -2906,6 +2906,9 @@ packages:
 
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+
+  tinyexec@0.2.0:
+    resolution: {integrity: sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==}
 
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
@@ -6059,6 +6062,8 @@ snapshots:
   text-table@0.2.0: {}
 
   tinybench@2.8.0: {}
+
+  tinyexec@0.2.0: {}
 
   tinypool@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^1.3.4
         version: 1.3.4
       tinyexec:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.0
+        version: 0.3.0
       unconfig:
         specifier: ^0.5.5
         version: 0.5.5
@@ -2907,8 +2907,8 @@ packages:
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
 
-  tinyexec@0.2.0:
-    resolution: {integrity: sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==}
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
 
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
@@ -6063,7 +6063,7 @@ snapshots:
 
   tinybench@2.8.0: {}
 
-  tinyexec@0.2.0: {}
+  tinyexec@0.3.0: {}
 
   tinypool@1.0.0: {}
 

--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -120,7 +120,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
   let pnpmStdout
 
   try {
-    pnpmStdout = (await exec('pnpm', ['ls', '--global', '--depth=0', '--json'])).stdout
+    pnpmStdout = (await exec('pnpm', ['ls', '--global', '--depth=0', '--json'], { throwOnError: true })).stdout
   }
   catch {
     return []
@@ -156,7 +156,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
 }
 
 async function loadGlobalNpmPackage(options: CheckOptions): Promise<GlobalPackageMeta> {
-  const { stdout } = await exec('npm', ['ls', '--global', '--depth=0', '--json'])
+  const { stdout } = await exec('npm', ['ls', '--global', '--depth=0', '--json'], { throwOnError: true })
   const npmOut = JSON.parse(stdout) as NpmOut
   const filter = createDependenciesFilter(options.include, options.exclude)
 
@@ -188,5 +188,5 @@ async function installPkg(pkg: GlobalPackageMeta) {
   const dependencies = dumpDependencies(changes, 'dependencies')
   const updateArgs = Object.entries(dependencies).map(([name, version]) => `${name}@${version}`)
   const installCommand = getCommand(pkg.agent, 'global', [...updateArgs])
-  await exec(installCommand)
+  await exec(installCommand, [], { throwOnError: true })
 }

--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { async as ezspawn } from '@jsdevtools/ez-spawn'
+import { exec } from 'tinyexec'
 import c from 'picocolors'
 import prompts from 'prompts'
 import { type Agent, getCommand } from '@antfu/ni'
@@ -120,7 +120,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
   let pnpmStdout
 
   try {
-    pnpmStdout = (await ezspawn('pnpm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })).stdout
+    pnpmStdout = (await exec('pnpm', ['ls', '--global', '--depth=0', '--json'])).stdout
   }
   catch {
     return []
@@ -156,7 +156,7 @@ async function loadGlobalPnpmPackage(options: CheckOptions): Promise<GlobalPacka
 }
 
 async function loadGlobalNpmPackage(options: CheckOptions): Promise<GlobalPackageMeta> {
-  const { stdout } = await ezspawn('npm', ['ls', '--global', '--depth=0', '--json'], { stdio: 'pipe' })
+  const { stdout } = await exec('npm', ['ls', '--global', '--depth=0', '--json'])
   const npmOut = JSON.parse(stdout) as NpmOut
   const filter = createDependenciesFilter(options.include, options.exclude)
 
@@ -188,5 +188,5 @@ async function installPkg(pkg: GlobalPackageMeta) {
   const dependencies = dumpDependencies(changes, 'dependencies')
   const updateArgs = Object.entries(dependencies).map(([name, version]) => `${name}@${version}`)
   const installCommand = getCommand(pkg.agent, 'global', [...updateArgs])
-  await ezspawn(installCommand, { stdio: 'inherit' })
+  await exec(installCommand)
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,11 +1,11 @@
 import path from 'node:path'
 import { expect, it } from 'vitest'
-import { async as ezspawn } from '@jsdevtools/ez-spawn'
+import { exec } from 'tinyexec'
 
 it('taze cli should just works', async () => {
   const binPath = path.resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await ezspawn(process.execPath, [binPath], { stdio: 'pipe' })
+  const proc = await exec(process.execPath, [binPath])
 
   expect(proc.stderr).toBe('')
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,7 +5,7 @@ import { exec } from 'tinyexec'
 it('taze cli should just works', async () => {
   const binPath = path.resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await exec(process.execPath, [binPath])
+  const proc = await exec(process.execPath, [binPath], { throwOnError: true })
 
   expect(proc.stderr).toBe('')
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Replacing `ezspawn` with a even lighter library, see also https://github.com/antfu/install-pkg/pull/14

### Linked Issues

N/A


### Additional context

https://github.com/antfu/install-pkg/pull/14