### PR TITLE
chore: bundle `npm-registry-fetch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@antfu/ni": "^0.23.0",
     "js-yaml": "^4.1.0",
-    "npm-registry-fetch": "^17.1.0",
     "ofetch": "^1.3.4",
     "package-manager-detector": "^0.2.0",
     "tinyexec": "^0.3.0",
@@ -67,6 +66,7 @@
     "fast-glob": "^3.3.2",
     "fast-npm-meta": "^0.2.2",
     "npm-package-arg": "^11.0.3",
+    "npm-registry-fetch": "^17.1.0",
     "picocolors": "^1.0.1",
     "prompts": "^2.4.2",
     "rimraf": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
-      npm-registry-fetch:
-        specifier: ^17.1.0
-        version: 17.1.0
       ofetch:
         specifier: ^1.3.4
         version: 1.3.4
@@ -102,6 +99,9 @@ importers:
       npm-package-arg:
         specifier: ^11.0.3
         version: 11.0.3
+      npm-registry-fetch:
+        specifier: ^17.1.0
+        version: 17.1.0
       picocolors:
         specifier: ^1.0.1
         version: 1.0.1


### PR DESCRIPTION
### Description

Re-land #109 for #138.

`npm-registry-fetch` was replaced by `ofetch` and was then brought back (https://github.com/antfu-collective/taze/commit/4a62457fd2680eed4784a28a79015e20b739fed2) to fix #122. But in the process `npm-registry-fetch` is no longer bundled.

### Linked Issues

#138

### Additional context

N/A