### PR TITLE
fix: cursor loss when exiting during installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "js-yaml": "^4.1.0",
     "ofetch": "^1.3.4",
     "package-manager-detector": "^0.2.0",
-    "restore-cursor": "^5.1.0",
     "tinyexec": "^0.3.0",
     "unconfig": "^0.5.5",
     "yargs": "^17.7.2"
@@ -70,6 +69,7 @@
     "npm-registry-fetch": "^17.1.0",
     "picocolors": "^1.0.1",
     "prompts": "^2.4.2",
+    "restore-cursor": "^5.1.0",
     "rimraf": "^6.0.1",
     "semver": "^7.6.3",
     "taze": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "js-yaml": "^4.1.0",
     "ofetch": "^1.3.4",
     "package-manager-detector": "^0.2.0",
+    "restore-cursor": "^5.1.0",
     "tinyexec": "^0.3.0",
     "unconfig": "^0.5.5",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       package-manager-detector:
         specifier: ^0.2.0
         version: 0.2.0
+      restore-cursor:
+        specifier: ^5.1.0
+        version: 5.1.0
       tinyexec:
         specifier: ^0.3.0
         version: 0.3.0
@@ -2137,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2307,6 +2314,10 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -2679,6 +2690,10 @@ packages:
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -5267,6 +5282,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-function@5.0.1: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.0.1:
@@ -5453,6 +5470,10 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   optionator@0.9.3:
     dependencies:
@@ -5796,6 +5817,11 @@ snapshots:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   retry@0.12.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       package-manager-detector:
         specifier: ^0.2.0
         version: 0.2.0
-      restore-cursor:
-        specifier: ^5.1.0
-        version: 5.1.0
       tinyexec:
         specifier: ^0.3.0
         version: 0.3.0
@@ -111,6 +108,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      restore-cursor:
+        specifier: ^5.1.0
+        version: 5.1.0
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import type { Argv } from 'yargs'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import c from 'picocolors'
+import restoreCursor from 'restore-cursor'
 import pkgJson from '../package.json'
 import { check } from './commands/check'
 import { usage } from './commands/usage'
@@ -150,3 +151,5 @@ yargs(hideBin(process.argv))
   .alias('v', 'version')
   .help()
   .argv
+
+restoreCursor()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Just like the title, when you press `ctrl+c` to exit when installing, cursor in terminal will hide.

![image](https://github.com/user-attachments/assets/c7d21bd8-bd88-4813-8f72-72e850df7cf3)
 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
