### PR TITLE
fix(vscode): check versions before sync

### DIFF
--- a/src/addons/vscode.ts
+++ b/src/addons/vscode.ts
@@ -1,4 +1,5 @@
 import type { Addon } from '../types'
+import semver from 'semver'
 
 /**
  * Sync VS Code engine with the version of `@types/vscode`
@@ -19,7 +20,7 @@ export const addonVSCode: Addon = {
       return
     }
 
-    if (version && pkg.raw.engines?.vscode !== version) {
+    if (version && semver.gt(version, pkg.raw.engines.vscode)) {
       // eslint-disable-next-line no-console
       console.log(`[taze addon] Updated VS Code engine field to ${version}`)
       // If the version is not a range (fixed version), we prepend it with a caret


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds versions check for addon vscode.

Only sync when `engins.vscode`'s version is smaller than `@types/vscode`'s.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

Fix https://github.com/antfu-collective/taze/issues/144

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

None.
