### PR TITLE
fix: invalid version when checking vscode engine

### DIFF
--- a/src/addons/vscode.ts
+++ b/src/addons/vscode.ts
@@ -10,6 +10,11 @@ export const addonVSCode: Addon = {
       return
     }
 
+    const minEngineVersion = semver.minVersion(pkg.raw.engines.vscode)
+    if (!minEngineVersion) {
+      return
+    }
+
     const version: string = pkg.raw.dependencies?.['@types/vscode']
       || pkg.raw.devDependencies?.['@types/vscode']
       || pkg.raw.peerDependencies?.['@types/vscode']
@@ -20,7 +25,7 @@ export const addonVSCode: Addon = {
       return
     }
 
-    if (version && semver.gt(version, pkg.raw.engines.vscode)) {
+    if (version && semver.gt(version, minEngineVersion)) {
       // eslint-disable-next-line no-console
       console.log(`[taze addon] Updated VS Code engine field to ${version}`)
       // If the version is not a range (fixed version), we prepend it with a caret


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I encountered this error when updating

```
TypeError: Invalid Version: ^1.92.0
    at new SemVer (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:7954:14)
    at compare (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:8438:33)
    at Object.gt (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:8515:30)
    at Object.beforeWrite (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:10218:27)
    at writePackageJSON (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:10340:32)
    at writePackage (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/shared/taze.GGCFjr0T.mjs:10413:14)
    at check (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/cli.mjs:8967:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.handler (file:///Users/hyoban/.npm/_npx/16d8e2cf83f8302f/node_modules/taze/dist/cli.mjs:9497:18)
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
