### PR TITLE
feat: add `timediff` option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,6 +133,11 @@ yargs(hideBin(process.argv))
           type: 'boolean',
           describe: 'include locked dependencies & devDependencies',
         })
+        .option('noTimeDiff', {
+          alias: 't',
+          type: 'boolean',
+          describe: 'do not display the time difference between the current and the updated version',
+        })
         .help()
     },
     async (args) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,10 +133,9 @@ yargs(hideBin(process.argv))
           type: 'boolean',
           describe: 'include locked dependencies & devDependencies',
         })
-        .option('noTimeDiff', {
-          alias: 't',
+        .option('timediff', {
           type: 'boolean',
-          describe: 'do not display the time difference between the current and the updated version',
+          describe: 'show time difference between the current and the updated version',
         })
         .help()
     },

--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -16,7 +16,7 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
   const {
     sort = 'diff-asc',
     group = true,
-    noTimeDiff = false,
+    timediff = true,
   } = options
 
   const checked = new Set<object>()
@@ -171,11 +171,11 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
           formatTable(versions.map((v, idx) => {
             return [
               (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
-              noTimeDiff ? '' : timeDifference(dep.currentVersionTime),
+              timediff ? timeDifference(dep.currentVersionTime) : '',
               c.gray(dep.currentVersion),
               c.dim(c.gray('→')),
               colorizeVersionDiff(dep.currentVersion, v.targetVersion),
-              noTimeDiff ? '' : timeDifference(v.time),
+              timediff ? timeDifference(v.time) : '',
             ]
           }), 'LLLL').join('\n'),
         )

--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -16,6 +16,7 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
   const {
     sort = 'diff-asc',
     group = true,
+    noTimeDiff = false,
   } = options
 
   const checked = new Set<object>()
@@ -170,11 +171,11 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
           formatTable(versions.map((v, idx) => {
             return [
               (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
-              timeDifference(dep.currentVersionTime),
+              noTimeDiff ? '' : timeDifference(dep.currentVersionTime),
               c.gray(dep.currentVersion),
               c.dim(c.gray('→')),
               colorizeVersionDiff(dep.currentVersion, v.targetVersion),
-              timeDifference(v.time),
+              noTimeDiff ? '' : timeDifference(v.time),
             ]
           }), 'LLLL').join('\n'),
         )

--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -18,6 +18,7 @@ export function renderChange(
   change: ResolvedDepChange,
   interactive?: InteractiveContext,
   grouped = false,
+  noTimeDiff = false,
 ) {
   const update = change.update && (!interactive || interactive.isChecked(change))
   const pre = interactive
@@ -34,13 +35,13 @@ export function renderChange(
   return [
     `${pre} ${update ? name : c.gray(name)}`,
     grouped ? '' : c.gray(DependenciesTypeShortMap[change.source]),
-    timeDifference(change.currentVersionTime),
+    noTimeDiff ? '' : timeDifference(change.currentVersionTime),
     c.gray(change.currentVersion),
     update ? c.dim(c.gray('→')) : '',
     update
       ? colorizeVersionDiff(change.currentVersion, change.targetVersion)
       : c.gray(c.strikethrough(change.targetVersion)),
-    update
+    update && !noTimeDiff
       ? timeDifference(change.targetVersionTime)
       : '',
     (change.latestVersionAvailable && semver.minVersion(change.targetVersion)!.toString() !== change.latestVersionAvailable)
@@ -99,7 +100,7 @@ export function renderChanges(
     )
 
     const table = formatTable(
-      changes.map(c => renderChange(c, interactive, group)),
+      changes.map(c => renderChange(c, interactive, group, options.noTimeDiff)),
       'LLRRRRRL',
     )
 

--- a/src/commands/check/render.ts
+++ b/src/commands/check/render.ts
@@ -18,7 +18,7 @@ export function renderChange(
   change: ResolvedDepChange,
   interactive?: InteractiveContext,
   grouped = false,
-  noTimeDiff = false,
+  timediff = true,
 ) {
   const update = change.update && (!interactive || interactive.isChecked(change))
   const pre = interactive
@@ -35,13 +35,13 @@ export function renderChange(
   return [
     `${pre} ${update ? name : c.gray(name)}`,
     grouped ? '' : c.gray(DependenciesTypeShortMap[change.source]),
-    noTimeDiff ? '' : timeDifference(change.currentVersionTime),
+    timediff ? timeDifference(change.currentVersionTime) : '',
     c.gray(change.currentVersion),
     update ? c.dim(c.gray('→')) : '',
     update
       ? colorizeVersionDiff(change.currentVersion, change.targetVersion)
       : c.gray(c.strikethrough(change.targetVersion)),
-    update && !noTimeDiff
+    update && timediff
       ? timeDifference(change.targetVersionTime)
       : '',
     (change.latestVersionAvailable && semver.minVersion(change.targetVersion)!.toString() !== change.latestVersionAvailable)
@@ -100,7 +100,7 @@ export function renderChanges(
     )
 
     const table = formatTable(
-      changes.map(c => renderChange(c, interactive, group, options.noTimeDiff)),
+      changes.map(c => renderChange(c, interactive, group, options.timediff ?? true)),
       'LLRRRRRL',
     )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,13 @@ export interface CheckOptions extends CommonOptions {
    * @description exclude the locked deps/devDeps by default
    */
   includeLocked?: boolean
+  /**
+   * Hide the time difference between the current and the updated version
+   *
+   * @default false
+   * @description hide the time difference
+   */
+  noTimeDiff?: boolean
 }
 
 export interface PackageMeta {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,12 +122,12 @@ export interface CheckOptions extends CommonOptions {
    */
   includeLocked?: boolean
   /**
-   * Hide the time difference between the current and the updated version
+   * Show time difference between the current and the updated version
    *
-   * @default false
+   * @default true
    * @description hide the time difference
    */
-  noTimeDiff?: boolean
+  timediff?: boolean
 }
 
 export interface PackageMeta {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds the `-t` option to hide the `time diff` on the updating version screen. 

![image](https://github.com/user-attachments/assets/a09493c5-6171-4a6e-b4f6-176192948841)
![image](https://github.com/user-attachments/assets/468d4122-ce23-485a-aac6-623792c68bab)


### Linked Issues

Fixes #148

### Additional context

Suggestions for better option name or different approach are welcomed
