### PR TITLE
chore: detect package manager to show in message after writing

### DIFF
--- a/src/commands/check/index.ts
+++ b/src/commands/check/index.ts
@@ -4,7 +4,7 @@ import type {
   PackageMeta,
 } from '../../types'
 /* eslint-disable no-console */
-import { parseNi, parseNu, run } from '@antfu/ni'
+import { parseNi, parseNu, run, detect } from '@antfu/ni'
 import c from 'picocolors'
 import prompts from 'prompts'
 import { builtinAddons } from '../../addons'
@@ -124,8 +124,9 @@ export async function check(options: CheckOptions) {
   }
   else if (hasChanges) {
     if (!options.install && !options.update && !options.interactive) {
+      const packageManager = await detect()
       console.log(
-        c.yellow(`ℹ changes written to package.json, run ${c.cyan('npm i')} to install updates.`),
+        c.yellow(`ℹ changes written to package.json, run ${c.cyan(`${packageManager} i`)} to install updates.`),
       )
     }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The message after running `taze -w` (without autoinstall) was hardcoded to `run npm i to install updates.`
This PR uses `detect()` from `ni` to show the correct package manager.

