### PR TITLE
feat: preserve yaml anchors and aliases w/ single string value when updating `pnpm-workspace.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "dependencies": {
     "@antfu/ni": "^23.2.0",
-    "js-yaml": "^4.1.0",
     "ofetch": "^1.4.1",
     "package-manager-detector": "^0.2.8",
     "tinyexec": "^0.3.2",
     "unconfig": "^0.6.1",
+    "yaml": "^2.7.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
@@ -48,7 +48,6 @@
     "@npmcli/config": "^10.0.0",
     "@types/cli-progress": "^3.11.6",
     "@types/debug": "^4.1.12",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.7",
     "@types/npm-package-arg": "^6.1.4",
     "@types/npm-registry-fetch": "^8.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@antfu/ni':
         specifier: ^23.2.0
         version: 23.2.0
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
@@ -26,6 +23,9 @@ importers:
       unconfig:
         specifier: ^0.6.1
         version: 0.6.1
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -45,9 +45,6 @@ importers:
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^22.10.7
         version: 22.10.7
@@ -1042,9 +1039,6 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3375,9 +3369,10 @@ packages:
     resolution: {integrity: sha512-4wZWvE398hCP7O8n3nXKu/vdq1HcH01ixYlCREaJL5NUMwQ0g3MaGFUBNSlmBtKmhbtVG/Cm6lyYmSVTEVil8A==}
     engines: {node: ^14.17.0 || >=16.0.0}
 
-  yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4127,8 +4122,6 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.6': {}
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6872,9 +6865,9 @@ snapshots:
     dependencies:
       eslint-visitor-keys: 3.4.3
       lodash: 4.17.21
-      yaml: 2.3.4
+      yaml: 2.7.0
 
-  yaml@2.3.4: {}
+  yaml@2.7.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -1,5 +1,4 @@
-import type { Agent } from 'package-manager-detector'
-import type { CheckOptions, PackageMeta, RawDep } from '../../types'
+import type { CheckOptions, GlobalPackageMeta, RawDep } from '../../types'
 /* eslint-disable no-console */
 import { getCommand } from '@antfu/ni'
 import c from 'picocolors'
@@ -27,10 +26,6 @@ interface PnpmOut {
       version: string
     }
   }
-}
-
-interface GlobalPackageMeta extends PackageMeta {
-  agent: Agent
 }
 
 export async function checkGlobal(options: CheckOptions) {

--- a/src/io/pnpmWorkspaces.ts
+++ b/src/io/pnpmWorkspaces.ts
@@ -1,7 +1,7 @@
 import type { CommonOptions, PackageMeta, RawDep } from '../types'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import YAML from 'js-yaml'
+import { parse, stringify } from 'yaml'
 import { dumpDependencies, parseDependency } from './dependencies'
 
 export async function loadPnpmWorkspace(
@@ -11,7 +11,7 @@ export async function loadPnpmWorkspace(
 ): Promise<PackageMeta[]> {
   const filepath = path.resolve(options.cwd ?? '', relative)
   const rawText = await fs.readFile(filepath, 'utf-8')
-  const raw = YAML.load(rawText) as any || {}
+  const raw = parse(rawText) as any || {}
 
   const catalogs: PackageMeta[] = []
 
@@ -76,5 +76,5 @@ export async function writePnpmWorkspace(
   }
 
   if (changed)
-    await fs.writeFile(pkg.filepath, YAML.dump(pkg.raw), 'utf-8')
+    await fs.writeFile(pkg.filepath, stringify(pkg.raw), 'utf-8')
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Agent } from 'package-manager-detector'
+import type { Document } from 'yaml'
 import type { MODE_CHOICES } from './constants'
 import type { SortOption } from './utils/sort'
 
@@ -130,7 +132,7 @@ export interface CheckOptions extends CommonOptions {
   timediff?: boolean
 }
 
-export interface PackageMeta {
+interface BasePackageMeta {
   /**
    * Package name
    */
@@ -139,10 +141,6 @@ export interface PackageMeta {
    * Is private package
    */
   private: boolean
-  /**
-   * Package type
-   */
-  type: 'package.json' | 'pnpm-workspace.yaml' | 'global'
   /**
    * Package version
    */
@@ -156,10 +154,6 @@ export interface PackageMeta {
    */
   relative: string
   /**
-   * Raw package.json Object
-   */
-  raw: any
-  /**
    * Dependencies
    */
   deps: RawDep[]
@@ -168,6 +162,34 @@ export interface PackageMeta {
    */
   resolved: ResolvedDepChange[]
 }
+
+export interface PackageJsonMeta extends BasePackageMeta {
+  /**
+   * Package type
+   */
+  type: 'package.json'
+  /**
+   * Raw package.json Object
+   */
+  raw: any
+}
+
+export interface GlobalPackageMeta extends BasePackageMeta {
+  agent: Agent
+  type: 'global'
+  raw: null
+}
+
+export interface PnpmWorkspaceMeta extends BasePackageMeta {
+  type: 'pnpm-workspace.yaml'
+  raw: any
+  document: Document
+}
+
+export type PackageMeta =
+  | PackageJsonMeta
+  | GlobalPackageMeta
+  | PnpmWorkspaceMeta
 
 export type DependencyFilter = (dep: RawDep) => boolean | Promise<boolean>
 export type DependencyResolvedCallback = (packageName: string | null, depName: string, progress: number, total: number) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,8 +183,6 @@ export interface GlobalPackageMeta extends BasePackageMeta {
 export interface PnpmWorkspaceMeta extends BasePackageMeta {
   type: 'pnpm-workspace.yaml'
   raw: any
-  // it's maintained in real time and is the final write-back
-  contents: any
   document: Document
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,8 @@ export interface GlobalPackageMeta extends BasePackageMeta {
 export interface PnpmWorkspaceMeta extends BasePackageMeta {
   type: 'pnpm-workspace.yaml'
   raw: any
+  // it's maintained in real time and is the final write-back
+  contents: any
   document: Document
 }
 

--- a/test/pnpmCatalog.test.ts
+++ b/test/pnpmCatalog.test.ts
@@ -11,10 +11,10 @@ it('pnpm catalog', async () => {
 
   expect(result.packages.map(p => p.name)).toMatchInlineSnapshot(`
     [
-      "@taze/monorepo-example",
       "catalog:default",
       "catalog:react17",
       "catalog:react18",
+      "@taze/monorepo-example",
     ]
   `)
 
@@ -25,39 +25,6 @@ it('pnpm catalog', async () => {
     })),
   ).toMatchInlineSnapshot(`
     [
-      {
-        "name": "@taze/monorepo-example",
-        "packages": [
-          [
-            "express",
-            "4.12.x",
-          ],
-          [
-            "lodash",
-            "^4.13.19",
-          ],
-          [
-            "multer",
-            "^0.1.8",
-          ],
-          [
-            "react-bootstrap",
-            "^0.22.6",
-          ],
-          [
-            "webpack",
-            "~1.9.10",
-          ],
-          [
-            "@types/lodash",
-            "^4.14.0",
-          ],
-          [
-            "typescript",
-            "3.5",
-          ],
-        ],
-      },
       {
         "name": "catalog:default",
         "packages": [
@@ -94,6 +61,39 @@ it('pnpm catalog', async () => {
           [
             "react-dom",
             "^18.2.0",
+          ],
+        ],
+      },
+      {
+        "name": "@taze/monorepo-example",
+        "packages": [
+          [
+            "express",
+            "4.12.x",
+          ],
+          [
+            "lodash",
+            "^4.13.19",
+          ],
+          [
+            "multer",
+            "^0.1.8",
+          ],
+          [
+            "react-bootstrap",
+            "^0.22.6",
+          ],
+          [
+            "webpack",
+            "~1.9.10",
+          ],
+          [
+            "@types/lodash",
+            "^4.14.0",
+          ],
+          [
+            "typescript",
+            "3.5",
           ],
         ],
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. `PackageMeta`, originally as an interface, is turned into a union type, and `GlobalPackageMeta` is exported
2. since `raw` cannot provide more precise information, `yaml`'s `Document` model is used to find anchors and aliases, thus `js-yaml` is dropped.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
fix #150 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
