### PR TITLE
fix(global): handle select no global npm packages

### DIFF
--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -62,6 +62,10 @@ export async function checkGlobal(options: CheckOptions) {
   if (options.interactive)
     resolvePkgs = await promptInteractive(resolvePkgs, options) as GlobalPackageMeta[]
 
+  if (!resolvePkgs.length) {
+    return exitCode
+  }
+
   const { lines, errLines } = renderPackages(resolvePkgs, options)
 
   const hasChanges = resolvePkgs.length && resolvePkgs.some(i => i.resolved.some(j => j.update))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

If you don't select `npm` global packages but choose other packages, the program will encounter an error due to command `npm i -g`.

```
❯ npm i -g
npm error code ENOENT
npm error syscall open
npm error path /Users/kevin/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/Users/kevin/package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: /Users/kevin/.npm/_logs/2025-02-02T20_42_50_448Z-debug-0.log
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
