### PR TITLE
fix: url version should be exclude

### DIFF
--- a/src/io/dependencies.ts
+++ b/src/io/dependencies.ts
@@ -28,7 +28,9 @@ export function setByPath(obj: any, path: string, value: any) {
 }
 
 export function parseDependencies(pkg: any, type: DepType, shouldUpdate: (name: string) => boolean): RawDep[] {
-  return Object.entries(getByPath(pkg, type) || {}).map(([name, { version, parents }]) => parseDependency(name, version, type, shouldUpdate, parents))
+  return Object.entries(getByPath(pkg, type) || {})
+    .filter(([_, { version }]) => !/^(?:http(s)?:|git\+|github:|file:)/.test(version))
+    .map(([name, { version, parents }]) => parseDependency(name, version, type, shouldUpdate, parents))
 }
 
 export function parseDependency(name: string, version: string, type: DepType, shouldUpdate: (name: string) => boolean, parents?: string[]): RawDep {

--- a/test/parseDependencies.test.ts
+++ b/test/parseDependencies.test.ts
@@ -62,6 +62,40 @@ describe('parseDependencies', () => {
       `)
   })
 
+  it('parse package `dependencies` should exclude URL version', () => {
+    const myPackage = {
+      name: '@taze/package1',
+      private: true,
+      dependencies: {
+        '@taze/not-exists': '^4.13.19',
+        '@typescript/lib-dom': 'npm:@types/web@^0.0.80',
+        "my-lib1": "https://example.com/packages/my-lib1-1.0.0.tgz",
+        "my-lib2": "git+https://github.com/user/my-lib2.git",
+        "my-lib3": "github:user/my-lib3#v1.2.3",
+        "my-lib4": "file:../my-lib4",
+      },
+    }
+    const result = parseDependencies(myPackage, 'dependencies', () => true)
+    expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "currentVersion": "^4.13.19",
+            "name": "@taze/not-exists",
+            "parents": [],
+            "source": "dependencies",
+            "update": true,
+          },
+          {
+            "currentVersion": "npm:@types/web@^0.0.80",
+            "name": "@typescript/lib-dom",
+            "parents": [],
+            "source": "dependencies",
+            "update": true,
+          },
+        ]
+      `)
+  })
+
   it('parse package `pnpm.overrides`', () => {
     const myPackage = {
       name: '@taze/package1',


### PR DESCRIPTION
### Description

https://docs.npmjs.com/cli/v9/configuring-npm/package-json#urls-as-dependencies

url address should be exclude


