### PR TITLE
fix: npm cli config load errors

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -8,6 +8,7 @@ async function _getNpmConfig() {
   const { default: NpmCliConfig } = await import('@npmcli/config')
   const npmcliConfig = new NpmCliConfig({
     definitions: {},
+    shorthands: [],
     npmPath: dirname(process.cwd()),
     flatten: (current, total) => {
       Object.assign(total, current)

--- a/src/utils/npmcliConfig.d.ts
+++ b/src/utils/npmcliConfig.d.ts
@@ -3,6 +3,7 @@ declare module '@npmcli/config' {
 
   export interface NpmcliConfigOptions {
     definitions: Recordable
+    shorthands: string[]
     npmPath: string
     flatten: (current: Recordable, total: Recordable) => void
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hey folks, this fix adds a missing param to the construction of `Config` from `@npmcli/config`—see [here](https://github.com/npm/cli/blob/config-v10.3.1/workspaces/config/lib/index.js#L69) for the non-optional param in the source of the package.

This removes errors that can occur during `await npmcliConfig.load()` [here](https://github.com/antfu-collective/taze/blob/cc4df7780fa9bb8bce9c2beedb8300ae7f808246/src/utils/npm.ts#L36). The errors probably stop part of taze's dep crawl, but I didn't dive very deep after coming up with this fix.

```
TypeError: Cannot convert undefined or null to object
```

<details><summary>🖼️ Errors example</summary>
<p>

<img width="509" height="768" alt="image" src="https://github.com/user-attachments/assets/ad6fef15-ec27-4db7-9688-cc14bf434a8f" />


</p>
</details> 


### Linked Issues

fix #196

### Additional context

Prior to [this change](https://github.com/npm/cli/commit/593c84921b0df963cef2ca7b13e44acc20cbd558#diff-cde3afb35a6731426f6bc36e409cfe497f391a40f807e9e65fb0ec93c515fe48R360-R364), the fact this hadn't already tripped an error is just luck, since this `shorthand` param has always been non-optional
