### PR TITLE
feat: add maturity period option to filter newly released packages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,12 +46,10 @@ cli
       options.mode = mode
     }
 
-    console.log('hello options', options)
     if ('maturityPeriod' in options && typeof options.maturityPeriod !== 'number') {
       options.maturityPeriod = 7
     }
 
-    console.log('hello options 2', options)
 
     const resolved = await resolveConfig(options)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,6 @@ cli
       options.maturityPeriod = 7
     }
 
-
     const resolved = await resolveConfig(options)
 
     let exitCode

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ cli
   .option('--timediff', 'show time difference between the current and the updated version')
   .option('--nodecompat', 'show package compatibility with current node version')
   .option('--peer', 'Include peerDependencies in the update process')
+  .option('--maturity-period [days]', 'wait period in days before upgrading to newly released packages (default: 7 when flag is used, 0 when not used)')
   .action(async (mode: RangeMode | undefined, options: Partial<CheckOptions>) => {
     if (mode) {
       if (!MODE_CHOICES.includes(mode)) {
@@ -44,6 +45,14 @@ cli
       }
       options.mode = mode
     }
+
+    console.log('hello options', options)
+    if ('maturityPeriod' in options && typeof options.maturityPeriod !== 'number') {
+      options.maturityPeriod = 7
+    }
+
+    console.log('hello options 2', options)
+
     const resolved = await resolveConfig(options)
 
     let exitCode

--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -142,8 +142,8 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
     dep: ResolvedDepChange,
   ): InteractiveRenderer {
     const versions = Object.entries({
-      minor: getVersionOfRange(dep, 'minor'),
-      patch: getVersionOfRange(dep, 'patch'),
+      minor: getVersionOfRange(dep, 'minor', options),
+      patch: getVersionOfRange(dep, 'patch', options),
       ...dep.pkgData.tags,
     })
       .map(([name, version]) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,4 +40,5 @@ export const DEFAULT_CHECK_OPTIONS: CheckOptions = {
   group: true,
   includeLocked: false,
   nodecompat: true,
+  maturityPeriod: 0,
 }

--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -10,10 +10,8 @@ import { diffSorter } from '../filters/diff-sorter'
 import { getPackageMode } from '../utils/config'
 import { getNpmConfig } from '../utils/npm'
 import { parsePnpmPackagePath, parseYarnPackagePath } from '../utils/package'
-import { fetchPackage } from '../utils/packument'
-import { filterDeprecatedVersions, filterVersionsByMaturityPeriod, getMaxSatisfying, getPrefixedVersion } from '../utils/versions'
 import { fetchJsrPackageMeta, fetchPackage } from '../utils/packument'
-import { filterDeprecatedVersions, getMaxSatisfying, getPrefixedVersion } from '../utils/versions'
+import { filterDeprecatedVersions, filterVersionsByMaturityPeriod, getMaxSatisfying, getPrefixedVersion } from '../utils/versions'
 
 const debug = {
   cache: _debug('taze:cache'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,13 @@ export interface CheckOptions extends CommonOptions {
    * @default true
    */
   nodecompat?: boolean
+  /**
+   * Wait period in days before upgrading to newly released packages
+   * This helps avoid potentially malicious packages released recently
+   *
+   * @default 0 (no waiting period)
+   */
+  maturityPeriod?: number
 }
 
 interface BasePackageMeta {

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -117,19 +117,14 @@ export function filterVersionsByMaturityPeriod(
   const now = new Date()
   const cutoffDate = new Date(now.getTime() - (maturityPeriodDays * 24 * 60 * 60 * 1000))
 
-  console.log(`[DEBUG] Filtering versions older than ${maturityPeriodDays} days (before ${cutoffDate.toISOString()})`)
-
   return versions.filter(version => {
     const versionTime = time[version]
     if (!versionTime) {
-      console.log(`[DEBUG] No time info for version ${version}, keeping it`)
       return true
     }
 
     const releaseDate = new Date(versionTime)
     const isMature = releaseDate < cutoffDate
-    
-    console.log(`[DEBUG] Version ${version} released at ${versionTime} (${releaseDate.toISOString()}) - ${isMature ? 'KEEP' : 'FILTER OUT'}`)
     
     return isMature
   })

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -106,9 +106,9 @@ export function filterDeprecatedVersions(versions: string[], deprecated: Record<
 }
 
 export function filterVersionsByMaturityPeriod(
-  versions: string[], 
-  time: Record<string, string> | undefined, 
-  maturityPeriodDays: number
+  versions: string[],
+  time: Record<string, string> | undefined,
+  maturityPeriodDays: number,
 ): string[] {
   if (!time || maturityPeriodDays <= 0) {
     return versions
@@ -117,7 +117,7 @@ export function filterVersionsByMaturityPeriod(
   const now = new Date()
   const cutoffDate = new Date(now.getTime() - (maturityPeriodDays * 24 * 60 * 60 * 1000))
 
-  return versions.filter(version => {
+  return versions.filter((version) => {
     const versionTime = time[version]
     if (!versionTime) {
       return true
@@ -125,7 +125,7 @@ export function filterVersionsByMaturityPeriod(
 
     const releaseDate = new Date(versionTime)
     const isMature = releaseDate < cutoffDate
-    
+
     return isMature
   })
 }

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -104,3 +104,33 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
 export function filterDeprecatedVersions(versions: string[], deprecated: Record<string, string | boolean>): string[] {
   return versions.filter(version => !deprecated[version])
 }
+
+export function filterVersionsByMaturityPeriod(
+  versions: string[], 
+  time: Record<string, string> | undefined, 
+  maturityPeriodDays: number
+): string[] {
+  if (!time || maturityPeriodDays <= 0) {
+    return versions
+  }
+
+  const now = new Date()
+  const cutoffDate = new Date(now.getTime() - (maturityPeriodDays * 24 * 60 * 60 * 1000))
+
+  console.log(`[DEBUG] Filtering versions older than ${maturityPeriodDays} days (before ${cutoffDate.toISOString()})`)
+
+  return versions.filter(version => {
+    const versionTime = time[version]
+    if (!versionTime) {
+      console.log(`[DEBUG] No time info for version ${version}, keeping it`)
+      return true
+    }
+
+    const releaseDate = new Date(versionTime)
+    const isMature = releaseDate < cutoffDate
+    
+    console.log(`[DEBUG] Version ${version} released at ${versionTime} (${releaseDate.toISOString()}) - ${isMature ? 'KEEP' : 'FILTER OUT'}`)
+    
+    return isMature
+  })
+}

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 import { getPackageData } from '../src/io/resolves'
-import { filterDeprecatedVersions, getMaxSatisfying, getVersionRangePrefix } from '../src/utils/versions'
+import { filterDeprecatedVersions, filterVersionsByMaturityPeriod, getMaxSatisfying, getVersionRangePrefix } from '../src/utils/versions'
 
 it('getVersionRange', () => {
   expect('~').toBe(getVersionRangePrefix('~1.2.3'))
@@ -128,4 +128,25 @@ it('deprecated filter', () => {
 
   const noDeprecated = filterDeprecatedVersions(versions, {})
   expect(noDeprecated).toEqual(versions)
+})
+
+it('maturity period filter', () => {
+  const now = new Date()
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+  const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000)
+
+  const versions = ['1.0.0', '1.1.0', '2.0.0']
+  const time = {
+    '1.0.0': eightDaysAgo.toISOString(),
+    '1.1.0': oneDayAgo.toISOString(),
+    '2.0.0': now.toISOString(),
+  }
+
+  // Test with 7 days - should filter out recent versions
+  const filtered = filterVersionsByMaturityPeriod(versions, time, 7)
+  expect(filtered).toEqual(['1.0.0'])
+
+  // Test with 0 days - should return all versions
+  const noFilter = filterVersionsByMaturityPeriod(versions, time, 0)
+  expect(noFilter).toEqual(versions)
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR implements a maturity period option that allows users to wait for a period of time before upgrading to newly released package versions.

### Scope of work
Filters out deprecated versions and prevents packages with deprecated current versions from being processed.

Filters out versions that are under a specified days of maturity dates from being processed.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Fixes #202

### Usage Example

```console
# No waiting period (default behavior)
taze

# Wait 7 days before upgrading to new versions (default when flag is used)
taze --maturity-period

# Wait 14 days (2 weeks) for extra security
taze --maturity-period 14

# Wait 1 day for testing
taze --maturity-period 1

# Combine with other options
taze --maturity-period 7 --mode minor --write
```


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I'm not sure this is exactly what you want for this feature, from the description of issue.
- Is `--maturity-period` meaningful for this feature?
- Is the `7 days` appropriate default value?

And in several cases you've seen, please feel free to discuss with me.
If you have any suggestions or want me to update my code, please let me know and I will update as soon as possible.
