### PR TITLE
chore: remove unused `yaml` & `fast-glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "restore-cursor": "^5.1.0",
     "tinyexec": "^1.0.1",
     "tinyglobby": "^0.2.14",
-    "unconfig": "^7.3.3",
-    "yaml": "^2.8.1"
+    "unconfig": "^7.3.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.2.2",
@@ -65,7 +64,6 @@
     "deepmerge": "^4.3.1",
     "detect-indent": "^7.0.1",
     "eslint": "^9.34.0",
-    "fast-glob": "^3.3.3",
     "fast-npm-meta": "^0.4.6",
     "npm-package-arg": "^13.0.0",
     "npm-registry-fetch": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       unconfig:
         specifier: ^7.3.3
         version: 7.3.3
-      yaml:
-        specifier: ^2.8.1
-        version: 2.8.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^5.2.2
@@ -96,9 +93,6 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.5.1)
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
       fast-npm-meta:
         specifier: ^0.4.6
         version: 0.4.6


### PR DESCRIPTION
I believe those are leftovers. taze have been using `pnpm-workspace-yaml` since https://github.com/antfu-collective/taze/commit/ad9796b8d0b299fd71f9010ccbb0dcb69dfcfcb4 (yaml is pulled from that dependency). I couldn't find where taze stopped using `fast-glob`. This should reduce install size by a bit