### PR TITLE
fix: correctly find max satisfying version from unsorted arrays

### DIFF
--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -70,7 +70,10 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
     version = tags.latest
   }
   else if (mode === 'newest') {
-    version = versions[versions.length - 1]
+    versions.forEach((ver) => {
+      if (!version || semver.gt(ver, version))
+        version = ver
+    })
   }
   else if (mode === 'next') {
     version = tags.next

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -127,6 +127,9 @@ it('getMaxSatisfying', async () => {
   ], '^2.0.0', 'default', {
     latest: '2.8.1',
   }))
+
+  // newest mode should return the actual newest version, not the last in array
+  expect('3.0.0').toBe(getMaxSatisfying(['1.0.0', '3.0.0', '2.0.0'], '', 'newest', {}))
 }, 10_000)
 
 it('deprecated filter', () => {


### PR DESCRIPTION
### Description

The `getMaxSatisfying` function assumed versions were sorted, but `Object.keys()` returns versions in arbitrary order from npm registry. This caused taze to suggest older compatible versions instead of the latest ones. Added comparison logic to track the actual maximum version during iteration. I've included a previously failing test for this.

### Linked Issues

Fixes https://github.com/antfu-collective/taze/issues/189

### Additional context

I've been confused for a hot minute why taze wouldn't want to update to 2.8.1 of the yaml library if not using `taze latest`.
