### PR TITLE
feat: expose `--concurrency` CLI option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ cli
   .option('--nodecompat', 'show package compatibility with current node version')
   .option('--peer', 'Include peerDependencies in the update process')
   .option('--maturity-period [days]', 'wait period in days before upgrading to newly released packages (default: 7 when flag is used, 0 when not used)')
+  .option('--concurrency', 'number of concurrent requests when resolving dependencies', { default: 10 })
   .action(async (mode: RangeMode | undefined, options: Partial<CheckOptions>) => {
     if (mode) {
       if (!MODE_CHOICES.includes(mode)) {


### PR DESCRIPTION
### Description

The PR follows https://github.com/antfu-collective/taze/commit/abdf4aec1d2839292d2c0a732237997623891832, allowing `concurrency` option to be set with a CLI flag as well. 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
