### PR TITLE
fix: #209 remove version locking `patch to minor` logic

### DIFF
--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -137,18 +137,6 @@ export function updateTargetVersion(
     = !!(dep.currentProvenance && !dep.targetProvenance) // trusted -> none, provenance -> none
       || (dep.currentProvenance === 'trustedPublisher' && dep.targetProvenance === true) // trusted -> provenance
 
-  if (versionLocked && semver.eq(dep.currentVersion, dep.targetVersion)) {
-    // for example: `taze`/`taze -P` is default mode (and it matched from patch to minor)
-    // - but this mode will always ignore the locked pkgs
-    // - so we need to reset the target
-    const { versions, time = {}, tags } = dep.pkgData
-    const targetVersion = getMaxSatisfying(versions, dep.currentVersion, 'minor', tags)
-    if (targetVersion) {
-      dep.targetVersion = targetVersion
-      dep.targetVersionTime = time[dep.targetVersion]
-    }
-  }
-
   try {
     const current = semver.minVersion(dep.currentVersion)!
     const target = semver.minVersion(dep.targetVersion)!

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -105,6 +105,29 @@ it('resolveDependency', async () => {
 
   // include locked
   options.includeLocked = true
+
+  options.mode = 'default'
+
+  expect(false).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
+
+  options.mode = 'major'
+
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
+
+  options.mode = 'minor'
+
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
+
+  options.mode = 'patch'
+
+  expect(false).toBe((await resolveDependency(makePkg('4.0.3'), options, filter)).update)
+
+  options.mode = 'latest'
+
+  expect(true).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
+
+  options.mode = 'newest'
+
   expect(true).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
 
   expect((await resolveDependency(makePkg(''), options, filter)).targetVersion)


### PR DESCRIPTION
…ests

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Refer to the previous discussion https://github.com/antfu-collective/taze/pull/215#issuecomment-3354364977

Based on "always respecting the specified update range", I removed the logic of patch to minor. Below is the comparison between taze v19.7.0 and the version after my fix.

Before：taze v19.7.0

<img width="1142" height="998" alt="taze-19 7 0" src="https://github.com/user-attachments/assets/b0030cdd-fe39-46fe-91af-00760ccb764f" />

After：taze pnpm patch

<img width="1131" height="1000" alt="taze-patch" src="https://github.com/user-attachments/assets/9c435747-5152-4040-9174-06ccd3645893" />

### Linked Issues

https://github.com/antfu-collective/taze/issues/209

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
