### PR TITLE
fix: guard npm global packages loading

### DIFF
--- a/src/commands/check/checkGlobal.ts
+++ b/src/commands/check/checkGlobal.ts
@@ -156,14 +156,17 @@ async function loadGlobalNpmPackage(options: CheckOptions): Promise<GlobalPackag
   const npmOut = JSON.parse(stdout) as NpmOut
   const filter = createDependenciesFilter(options.include, options.exclude)
 
-  const deps: RawDep[] = Object.entries(npmOut.dependencies)
-    .filter(([_name, i]) => i?.version)
-    .map(([name, i]) => ({
-      name,
-      currentVersion: `^${i.version}`,
-      update: filter(name),
-      source: 'dependencies',
-    }))
+  let deps: RawDep[] = []
+  if ('dependencies' in npmOut) {
+    deps = Object.entries(npmOut.dependencies)
+      .filter(([_name, i]) => i?.version)
+      .map(([name, i]) => ({
+        name,
+        currentVersion: `^${i.version}`,
+        update: filter(name),
+        source: 'dependencies',
+      }))
+  }
 
   return {
     agent: 'npm',


### PR DESCRIPTION
### Description

Here is my `npm ls --global --depth=0 --json` output, and there is no `dependencies`:

```
$ npm ls --global --depth=0 --json
{
  "name": "lib"
}
```

Thus, `taze` throws a `TypeError` with `taze -Ig`:

```
  const deps = Object.entries(npmOut.dependencies).filter(([_name, i]) => i?.version).map(([name, i]) => ({
                      ^

TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
```

The PR guards that.

### Linked Issues

N/A

### Additional context

Should we adds extra type-check here?