### PR TITLE
refactor: replace tinyglobby dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "pnpm-workspace-yaml": "^1.3.0",
     "restore-cursor": "^5.1.0",
     "tinyexec": "^1.0.1",
-    "tinyglobby": "^0.2.15",
     "unconfig": "^7.3.3",
     "yaml": "^2.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.1
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
       unconfig:
         specifier: ^7.3.3
         version: 7.3.3


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Replaces unnecessary dependency on `tinyglobby` with built-in Node `fs.promises.glob`.