### PR TITLE
Add available modes documentation to `--help` output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { SORT_CHOICES } from './utils/sort'
 const cli: CAC = cac('taze')
 
 cli
-  .command('[mode]', 'Keeps your deps fresh')
+  .command('[mode]', `Update mode (version range to check). Available: ${MODE_CHOICES.join(' | ')}`)
   .option('--cwd, -C <cwd>', 'specify the current working directory')
   .option('--loglevel <level>', `log level (${LOG_LEVELS.join('|')})`)
   .option('--fail-on-outdated', 'exit with code 1 if outdated dependencies are found')
@@ -41,7 +41,7 @@ cli
   .action(async (mode: RangeMode | undefined, options: Partial<CheckOptions>) => {
     if (mode) {
       if (!MODE_CHOICES.includes(mode)) {
-        console.error(`Invalid mode: ${mode}. Please use one of the following: ${MODE_CHOICES.join('|')}`)
+        console.error(`Invalid mode: ${mode}. Please use one of the following: ${MODE_CHOICES.join(' | ')}`)
         process.exit(1)
       }
       options.mode = mode


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

I've struggled many times to understand which modes are supported. I run the command with random symbols to see an error with the modes list because `--help` doesn't provide this information.

### Additional context

Just added a list of available modes and improved readability by adding spaces in the separator.
