### PR TITLE
test: stable tests cross os

### DIFF
--- a/test/bunCatalog.test.ts
+++ b/test/bunCatalog.test.ts
@@ -72,7 +72,9 @@ describe('bun catalog integration', () => {
     expect(
       result.packages.flatMap(p => ({
         name: p.name,
-        packages: p.resolved.map(r => [r.name, r.targetVersion]),
+        packages: p.resolved
+          .map(r => [r.name, r.targetVersion])
+          .sort((a, b) => a[0].localeCompare(b[0])),
       })),
     ).toMatchInlineSnapshot(`
       [
@@ -119,6 +121,10 @@ describe('bun catalog integration', () => {
           "name": "@taze/bun-monorepo-example",
           "packages": [
             [
+              "@types/lodash",
+              "^4.14.0",
+            ],
+            [
               "express",
               "4.12.x",
             ],
@@ -135,16 +141,12 @@ describe('bun catalog integration', () => {
               "^0.22.6",
             ],
             [
-              "webpack",
-              "~1.9.10",
-            ],
-            [
-              "@types/lodash",
-              "^4.14.0",
-            ],
-            [
               "typescript",
               "3.5",
+            ],
+            [
+              "webpack",
+              "~1.9.10",
             ],
           ],
         },

--- a/test/pnpmCatalog.test.ts
+++ b/test/pnpmCatalog.test.ts
@@ -44,7 +44,9 @@ it('pnpm catalog', async () => {
   expect(
     result.packages.flatMap(p => ({
       name: p.name,
-      packages: p.resolved.map(r => [r.name, r.targetVersion]),
+      packages: p.resolved
+        .map(r => [r.name, r.targetVersion])
+        .sort((a, b) => a[0].localeCompare(b[0])),
     })),
   ).toMatchInlineSnapshot(`
     [
@@ -100,6 +102,10 @@ it('pnpm catalog', async () => {
         "name": "@taze/monorepo-example",
         "packages": [
           [
+            "@types/lodash",
+            "^4.14.0",
+          ],
+          [
             "express",
             "4.12.x",
           ],
@@ -116,16 +122,12 @@ it('pnpm catalog', async () => {
             "^0.22.6",
           ],
           [
-            "webpack",
-            "~1.9.10",
-          ],
-          [
-            "@types/lodash",
-            "^4.14.0",
-          ],
-          [
             "typescript",
             "3.5",
+          ],
+          [
+            "webpack",
+            "~1.9.10",
           ],
         ],
       },


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

The PR follows https://github.com/antfu-collective/taze/commit/31c6fe8dfc177e83c0699677abad98a8729489e4, which sorts `bun` and `pnpm` catalog tests as well to ensure they are stable across OS, too.

### Linked Issues

The PR fixes failing CI in #240.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
