### PR TITLE
docs: fix 'Configures' to 'Configuration' in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check up to <b>patch</b> updates
 <img src='./screenshots/r-default.png' width='600' alt='Recursive mode default' />
 </p>
 
-## Configures
+## Configuration
 
 See `taze --help` for more details
 


### PR DESCRIPTION
Fixes incorrect section heading 'Configures' to the proper grammatical form 'Configuration' in the README.md documentation.