### PR TITLE
feat: interactive tui exit on `q`

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -96,6 +96,7 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
       onKey(key) {
         switch (key.name) {
           case 'escape':
+          case 'q':
             process.exit()
           case 'enter':
           case 'return':


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Exit taze interactive mode with <kbd>q</kbd>.

### Linked Issues

Similar to https://github.com/antfu-collective/taze/pull/80.

### Additional context

<kbd>q</kbd> as the universal quit shortcut is a common practice in Terminal UI applications:

- `git log` and `git diff`
- `man`
- `less` and `more`
- `top` and `htop`
- `journalctl` (on Linux)