### PR TITLE
fix: ignoring nested bun workspaces and env support for .npmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,11 @@
     "detect-indent": "7.0.2",
     "emoji-regex": "8.0.0",
     "fast-npm-meta": "1.4.2",
-    "get-npm-meta": "0.1.1",
+    "get-npm-meta": "0.1.2",
     "is-fullwidth-code-point": "3.0.0",
     "kleur": "4.1.5",
     "ms": "2.1.3",
-    "semver-es": "0.1.0",
+    "semver-es": "0.1.1",
     "sisteransi": "1.0.5",
     "string-width": "4.2.3",
     "strip-ansi": "6.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,11 +50,11 @@ catalogs:
       specifier: ^7.0.2
       version: 7.0.2
     get-npm-meta:
+      specifier: ^0.1.2
+      version: 0.1.2
+    semver-es:
       specifier: ^0.1.1
       version: 0.1.1
-    semver-es:
-      specifier: ^0.1.0
-      version: 0.1.0
   prod:
     '@antfu/ni':
       specifier: ^30.0.0
@@ -191,10 +191,10 @@ importers:
         version: 10.1.0(jiti@2.6.1)
       get-npm-meta:
         specifier: catalog:inlined
-        version: 0.1.1
+        version: 0.1.2
       semver-es:
         specifier: catalog:inlined
-        version: 0.1.0
+        version: 0.1.1
       taze:
         specifier: workspace:*
         version: 'link:'
@@ -1709,8 +1709,8 @@ packages:
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
-  get-npm-meta@0.1.1:
-    resolution: {integrity: sha512-YoFCXyeCTXHK2ppdKlDnMP5JQEyYC4Ey/vwT3sGu9xLe8YUJyyIrZSKzkVsTg0255W/xBXD1h68OxhbNjxRsgQ==}
+  get-npm-meta@0.1.2:
+    resolution: {integrity: sha512-iMKe4T1dAR4VEgAGGdxY/RQIokHgA3RcmcUsM/DSt0lGE65clXGV8lSPf6v0rKhks0cM2moLw5dyV5raZcQmdg==}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -2163,8 +2163,8 @@ packages:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
 
-  semver-es@0.1.0:
-    resolution: {integrity: sha512-ugjCvvVx7kMsK2VC/M2aclMEet0XaqpXlm8bt/tJGIRxxgWJq8laZjIoEHnjhwf72gXD5rIXP3WsIMABcsZgLg==}
+  semver-es@0.1.1:
+    resolution: {integrity: sha512-EqJ7FSA1KH6SmsaNxZnoDVJOwCTD0DhBlDLsTl2+cMRXtKSvxIRU6fYE/Je9JU7e3Tbrq8S4mphU56F4/kOQ7A==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3872,7 +3872,7 @@ snapshots:
 
   fzf@0.5.2: {}
 
-  get-npm-meta@0.1.1:
+  get-npm-meta@0.1.2:
     dependencies:
       fast-npm-meta: 1.4.2
 
@@ -4527,7 +4527,7 @@ snapshots:
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
 
-  semver-es@0.1.0: {}
+  semver-es@0.1.1: {}
 
   semver@7.7.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,8 @@ catalogs:
     debug: ^4.4.3
     deepmerge: ^4.3.1
     detect-indent: ^7.0.2
-    get-npm-meta: ^0.1.1
-    semver-es: ^0.1.0
+    get-npm-meta: ^0.1.2
+    semver-es: ^0.1.1
   prod:
     '@antfu/ni': ^30.0.0
     '@henrygd/queue': ^1.2.0

--- a/src/io/packages.ts
+++ b/src/io/packages.ts
@@ -153,6 +153,10 @@ export async function loadPackages(options: CommonOptions): Promise<PackageMeta[
         const yarnWorkspace = await findUp('.yarnrc.yml', { cwd: absolute, stopAt: cwd })
         if (yarnWorkspace && dirname(yarnWorkspace) !== cwd)
           return []
+        const bunLock = await findUp('bun.lockb', { cwd: absolute, stopAt: cwd })
+          || await findUp('bun.lock', { cwd: absolute, stopAt: cwd })
+        if (bunLock && dirname(bunLock) !== cwd)
+          return []
         return [packagePath]
       }),
     )).flat()

--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -59,7 +59,7 @@ export async function dumpCache() {
   }
 }
 
-export async function getPackageData(name: string, protocol: Protocol = 'npm'): Promise<PackageData> {
+export async function getPackageData(name: string, protocol: Protocol = 'npm', cwd?: string): Promise<PackageData> {
   let error: any
   const cacheName = `${protocol}:${name}`
 
@@ -75,7 +75,7 @@ export async function getPackageData(name: string, protocol: Protocol = 'npm'): 
 
   try {
     debug.resolve(`resolving ${cacheName}`)
-    const data = protocol === 'jsr' ? await fetchJsrPackageMeta(name) : await fetchPackage(name, false)
+    const data = protocol === 'jsr' ? await fetchJsrPackageMeta(name) : await fetchPackage(name, false, cwd)
 
     if (data) {
       cache[cacheName] = { data, cacheTime: now() }
@@ -240,7 +240,7 @@ export async function resolveDependency(
     resolvedName = packages.pop() ?? dep.name
   }
 
-  const pkgData = await getPackageData(resolvedName, dep.protocol)
+  const pkgData = await getPackageData(resolvedName, dep.protocol, options.cwd)
   const { tags, error, deprecated } = pkgData
 
   dep.pkgData = pkgData

--- a/src/utils/packument.ts
+++ b/src/utils/packument.ts
@@ -48,9 +48,10 @@ const fetchWithUserAgent: typeof fetch = (input, init) => {
   return ofetch(input, { ...init, headers })
 }
 
-export async function fetchPackage(spec: string, force = false): Promise<PackageData> {
+export async function fetchPackage(spec: string, force: boolean = false, cwd?: string): Promise<PackageData> {
   const data = await Promise.race([
     getVersions(spec, {
+      cwd,
       force,
       fetch: fetchWithUserAgent,
       metadata: true,


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

This PR makes recursive package discovery skip nested Bun workspaces when `ignoreOtherWorkspaces` is enabled.

restores support for `environment` variables in `.npmrc`. [upstream pr](https://github.com/jinghaihan/get-npm-meta/pull/1)

Pass the target project `cwd` through to get-npm-meta so `taze --cwd <project>` reads the correct `.npmrc`.