### PR TITLE
fix: don't use `Array.fromAsync` with tinyglobby glob

### DIFF
--- a/src/io/packages.ts
+++ b/src/io/packages.ts
@@ -130,12 +130,12 @@ export async function loadPackages(options: CommonOptions): Promise<PackageMeta[
         packagesNames.push(jsonPkg)
       }
     }
-
-    packagesNames = packagesNames.sort((a, b) => a.localeCompare(b))
   }
   else {
-    packagesNames = await Array.fromAsync(await glob('package.{yaml,json}', { cwd }))
+    packagesNames = await glob('package.{yaml,json}', { cwd })
   }
+
+  packagesNames = packagesNames.sort((a, b) => a.localeCompare(b))
 
   if (options.ignoreOtherWorkspaces) {
     packagesNames = (await Promise.all(

--- a/test/bunCatalog.test.ts
+++ b/test/bunCatalog.test.ts
@@ -36,7 +36,7 @@ vitest.mock('../src/io/resolves.ts', async (importOriginal) => {
       name: 'react',
       currentVersion: '^18.2.0',
       source: 'bun-workspace',
-      targetVersion: '^18.2.0',
+      targetVersion: '^19.2.4',
       diff: null,
       resolveError: null,
       update: false,
@@ -63,8 +63,8 @@ describe('bun catalog integration', () => {
     expect(result.packages.map(p => p.name)).toMatchInlineSnapshot(`
       [
         "bun-catalog:default",
-        "bun-catalog:react17",
         "bun-catalog:react18",
+        "bun-catalog:react19",
         "@taze/bun-monorepo-example",
       ]
     `)
@@ -83,24 +83,11 @@ describe('bun catalog integration', () => {
           "packages": [
             [
               "react",
-              "^18.2.0",
+              "^19.2.4",
             ],
             [
               "react-dom",
-              "^18.2.0",
-            ],
-          ],
-        },
-        {
-          "name": "bun-catalog:react17",
-          "packages": [
-            [
-              "react",
-              "^17.0.2",
-            ],
-            [
-              "react-dom",
-              "^17.0.2",
+              "^19.2.4",
             ],
           ],
         },
@@ -114,6 +101,19 @@ describe('bun catalog integration', () => {
             [
               "react-dom",
               "^18.2.0",
+            ],
+          ],
+        },
+        {
+          "name": "bun-catalog:react19",
+          "packages": [
+            [
+              "react",
+              "^19.2.4",
+            ],
+            [
+              "react-dom",
+              "^19.2.4",
             ],
           ],
         },
@@ -161,13 +161,13 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          'react': '^18.2.0',
-          'react-dom': '^18.2.0',
+          'react': '^19.2.4',
+          'react-dom': '^19.2.4',
         },
         catalogs: {
-          react17: {
-            'react': '^17.0.2',
-            'react-dom': '^17.0.2',
+          react18: {
+            'react': '^18.2.0',
+            'react-dom': '^18.2.0',
           },
         },
       },
@@ -177,8 +177,8 @@ describe('bun catalog write functionality', () => {
       name: 'bun-catalog:default',
       resolved: [
         // testing purpose - simulate updated versions
-        { name: 'react', targetVersion: '^18.3.1', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'minor' } as any,
-        { name: 'react-dom', targetVersion: '^18.3.1', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'minor' } as any,
+        { name: 'react', targetVersion: '^19.2.4', source: 'bun-workspace', update: true, currentVersion: '^19.0.0', diff: 'minor' } as any,
+        { name: 'react-dom', targetVersion: '^19.2.4', source: 'bun-workspace', update: true, currentVersion: '^19.0.0', diff: 'minor' } as any,
       ],
       raw: packageJsonRaw,
       filepath: '/tmp/package.json',
@@ -191,16 +191,16 @@ describe('bun catalog write functionality', () => {
 
     await bunWorkspaces.writeBunWorkspace(pkg, {})
 
-    expect(output).toContain('"react": "^18.3.1"')
-    expect(output).toContain('"react-dom": "^18.3.1"')
+    expect(output).toContain('"react": "^19.2.4"')
+    expect(output).toContain('"react-dom": "^19.2.4"')
 
     // Verify the JSON structure is maintained
     const writtenJson = JSON.parse(output!)
-    expect(writtenJson.workspaces.catalog.react).toBe('^18.3.1')
-    expect(writtenJson.workspaces.catalog['react-dom']).toBe('^18.3.1')
+    expect(writtenJson.workspaces.catalog.react).toBe('^19.2.4')
+    expect(writtenJson.workspaces.catalog['react-dom']).toBe('^19.2.4')
 
     // Ensure other catalogs are preserved
-    expect(writtenJson.workspaces.catalogs.react17.react).toBe('^17.0.2')
+    expect(writtenJson.workspaces.catalogs.react18.react).toBe('^18.2.0')
   })
 
   it('should update named catalog in package.json', async () => {
@@ -208,28 +208,28 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          'react': '^18.2.0',
-          'react-dom': '^18.2.0',
+          'react': '^19.2.4',
+          'react-dom': '^19.2.4',
         },
         catalogs: {
-          react17: {
-            'react': '^17.0.2',
-            'react-dom': '^17.0.2',
-          },
           react18: {
             'react': '^18.2.0',
             'react-dom': '^18.2.0',
+          },
+          react19: {
+            'react': '^19.2.4',
+            'react-dom': '^19.2.4',
           },
         },
       },
     }
 
     const pkg: BunWorkspaceMeta = {
-      name: 'bun-catalog:react17',
+      name: 'bun-catalog:react19',
       resolved: [
         // testing purpose - simulate updated versions
-        { name: 'react', targetVersion: '^17.0.3', source: 'bun-workspace', update: true, currentVersion: '^17.0.2', diff: 'patch' } as any,
-        { name: 'react-dom', targetVersion: '^17.0.3', source: 'bun-workspace', update: true, currentVersion: '^17.0.2', diff: 'patch' } as any,
+        { name: 'react', targetVersion: '^19.2.4', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'patch' } as any,
+        { name: 'react-dom', targetVersion: '^19.2.4', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'patch' } as any,
       ],
       raw: packageJsonRaw,
       filepath: '/tmp/package.json',
@@ -244,11 +244,11 @@ describe('bun catalog write functionality', () => {
 
     // Verify the JSON structure is updated correctly
     const writtenJson = JSON.parse(output!)
-    expect(writtenJson.workspaces.catalogs.react17.react).toBe('^17.0.3')
-    expect(writtenJson.workspaces.catalogs.react17['react-dom']).toBe('^17.0.3')
+    expect(writtenJson.workspaces.catalogs.react18.react).toBe('^18.2.0')
+    expect(writtenJson.workspaces.catalogs.react18['react-dom']).toBe('^18.2.0')
 
     // Ensure default catalog and other catalogs are preserved
-    expect(writtenJson.workspaces.catalog.react).toBe('^18.2.0')
+    expect(writtenJson.workspaces.catalog.react).toBe('^19.2.4')
     expect(writtenJson.workspaces.catalogs.react18.react).toBe('^18.2.0')
   })
 
@@ -257,7 +257,7 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          react: '^18.2.0',
+          react: '^19.2.4',
         },
       },
     }
@@ -286,7 +286,7 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          react: '^18.2.0',
+          react: '^19.2.4',
         },
       },
     }, null, 4)
@@ -298,7 +298,7 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          react: '^18.2.0',
+          react: '^19.2.4',
         },
       },
     }
@@ -306,7 +306,7 @@ describe('bun catalog write functionality', () => {
     const pkg: BunWorkspaceMeta = {
       name: 'bun-catalog:default',
       resolved: [
-        { name: 'react', targetVersion: '^19.0.0', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'major' } as any,
+        { name: 'react', targetVersion: '^20.0.0', source: 'bun-workspace', update: true, currentVersion: '^19.2.4', diff: 'major' } as any,
       ],
       raw: packageJsonRaw,
       filepath: '/tmp/package.json',
@@ -331,7 +331,7 @@ describe('bun catalog write functionality', () => {
       name: '@test/bun-workspace',
       workspaces: {
         catalog: {
-          react: '^18.2.0',
+          react: '^19.2.4',
         },
       },
     }
@@ -339,7 +339,7 @@ describe('bun catalog write functionality', () => {
     const pkg: BunWorkspaceMeta = {
       name: 'bun-catalog:default',
       resolved: [
-        { name: 'react', targetVersion: '^19.0.0', source: 'bun-workspace', update: true, currentVersion: '^18.2.0', diff: 'major' } as any,
+        { name: 'react', targetVersion: '^20.0.0', source: 'bun-workspace', update: true, currentVersion: '^19.2.4', diff: 'major' } as any,
       ],
       raw: packageJsonRaw,
       filepath: '/tmp/nonexistent/package.json',

--- a/test/catalogRender.test.ts
+++ b/test/catalogRender.test.ts
@@ -72,7 +72,7 @@ describe('catalog display name consistency', () => {
 
   it('should style named catalogs correctly for all managers', () => {
     for (const prefix of ['pnpm-catalog:', 'bun-catalog:', 'yarn-catalog:']) {
-      const catalogName = 'react17'
+      const catalogName = 'react18'
       const source = prefix.replace('-catalog:', '-workspace')
       const pkg = makePkg(`${prefix}${catalogName}`, [makeChange('react', source)])
       const { lines } = renderChanges(pkg, options)

--- a/test/fixtures/bun-catalog/package.json
+++ b/test/fixtures/bun-catalog/package.json
@@ -4,17 +4,17 @@
   "workspaces": {
     "packages": ["packages/*"],
     "catalog": {
-      "react": "^18.2.0",
-      "react-dom": "^18.2.0"
+      "react": "^19.2.4",
+      "react-dom": "^19.2.4"
     },
     "catalogs": {
-      "react17": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      },
       "react18": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+      },
+      "react19": {
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
       }
     }
   },

--- a/test/fixtures/package-yaml/package.yaml
+++ b/test/fixtures/package-yaml/package.yaml
@@ -5,13 +5,13 @@ private: false
 dependencies:
   express: 4.12.x
   lodash: ^4.13.19
-  react: ^19.1.1
+  react: ^19.2.4
 devDependencies:
   '@types/lodash': ^4.14.0
   typescript: '3.5'
   webpack: ~5.101.3
 peerDependencies:
-  react-dom: ^18.2.0
+  react-dom: ^19.2.4
 optionalDependencies:
   multer: ^0.1.8
 packageManager: pnpm@10.19.0

--- a/test/fixtures/pnpm-catalog/pnpm-workspace.yaml
+++ b/test/fixtures/pnpm-catalog/pnpm-workspace.yaml
@@ -2,17 +2,17 @@ packages:
   - '!**/test/**'
 
 catalog:
-  react: ^18.2.0
-  react-dom: ^18.2.0
+  react: ^19.2.4
+  react-dom: ^19.2.4
 
 catalogs:
-  react17:
-    react: ^17.0.2
-    react-dom: ^17.0.2
-
   react18:
     react: ^18.2.0
     react-dom: ^18.2.0
+
+  react19:
+    react: ^19.2.4
+    react-dom: ^^19.2.4
 
 overrides:
   vue: ~3.3.0

--- a/test/fixtures/yarn-catalog/.yarnrc.yml
+++ b/test/fixtures/yarn-catalog/.yarnrc.yml
@@ -1,14 +1,14 @@
 defaultProtocol: 'npm:'
 
 catalog:
-  react: ^18.2.0
-  react-dom: ^18.2.0
+  react: ^19.2.4
+  react-dom: ^19.2.4
 
 catalogs:
-  react17:
-    react: ^17.0.2
-    react-dom: ^17.0.2
-
   react18:
     react: ^18.2.0
     react-dom: ^18.2.0
+
+  react19:
+    react: ^19.2.4
+    react-dom: ^19.2.4

--- a/test/packageYaml.test.ts
+++ b/test/packageYaml.test.ts
@@ -91,7 +91,7 @@ describe('package.yaml functionality', () => {
     }))
     expect(firstPackage.deps).toContainEqual(expect.objectContaining({
       name: 'react-dom',
-      currentVersion: '^18.2.0',
+      currentVersion: '^19.2.4',
       source: 'peerDependencies',
     }))
     expect(firstPackage.deps).toContainEqual(expect.objectContaining({

--- a/test/pnpmCatalog.test.ts
+++ b/test/pnpmCatalog.test.ts
@@ -34,8 +34,8 @@ it('pnpm catalog', async () => {
   expect(result.packages.map(p => p.name)).toMatchInlineSnapshot(`
     [
       "pnpm-catalog:default",
-      "pnpm-catalog:react17",
       "pnpm-catalog:react18",
+      "pnpm-catalog:react19",
       "pnpm-workspace:overrides",
       "@taze/monorepo-example",
     ]
@@ -55,24 +55,11 @@ it('pnpm catalog', async () => {
         "packages": [
           [
             "react",
-            "^18.2.0",
+            "^19.2.4",
           ],
           [
             "react-dom",
-            "^18.2.0",
-          ],
-        ],
-      },
-      {
-        "name": "pnpm-catalog:react17",
-        "packages": [
-          [
-            "react",
-            "^17.0.2",
-          ],
-          [
-            "react-dom",
-            "^17.0.2",
+            "^19.2.4",
           ],
         ],
       },
@@ -86,6 +73,19 @@ it('pnpm catalog', async () => {
           [
             "react-dom",
             "^18.2.0",
+          ],
+        ],
+      },
+      {
+        "name": "pnpm-catalog:react19",
+        "packages": [
+          [
+            "react",
+            "^19.2.4",
+          ],
+          [
+            "react-dom",
+            "^^19.2.4",
           ],
         ],
       },

--- a/test/yarnCatalog.test.ts
+++ b/test/yarnCatalog.test.ts
@@ -34,8 +34,8 @@ it('yarn catalog', async () => {
   expect(result.packages.map(p => p.name)).toMatchInlineSnapshot(`
     [
       "yarn-catalog:default",
-      "yarn-catalog:react17",
       "yarn-catalog:react18",
+      "yarn-catalog:react19",
       "@taze/monorepo-example",
     ]
   `)
@@ -54,24 +54,11 @@ it('yarn catalog', async () => {
         "packages": [
           [
             "react",
-            "^18.2.0",
+            "^19.2.4",
           ],
           [
             "react-dom",
-            "^18.2.0",
-          ],
-        ],
-      },
-      {
-        "name": "yarn-catalog:react17",
-        "packages": [
-          [
-            "react",
-            "^17.0.2",
-          ],
-          [
-            "react-dom",
-            "^17.0.2",
+            "^19.2.4",
           ],
         ],
       },
@@ -85,6 +72,19 @@ it('yarn catalog', async () => {
           [
             "react-dom",
             "^18.2.0",
+          ],
+        ],
+      },
+      {
+        "name": "yarn-catalog:react19",
+        "packages": [
+          [
+            "react",
+            "^19.2.4",
+          ],
+          [
+            "react-dom",
+            "^19.2.4",
           ],
         ],
       },
@@ -163,7 +163,7 @@ describe('yarn catalog update w/ yaml anchors and aliases', () => {
   it('should preserve yaml anchors and aliases with single string value, when anchor is defined in a separate field', async () => {
     const workspaceYamlContents = `
     defines:
-      - &react ^18.2.0
+      - &react ^19.2.4
 
     catalog:
       react: *react


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
`glob` from `tinyglobby` returns a `Promise<string[]>`, we don't need to use `Array.fromAsync` here yet.

This PR includes:
- sort the packages when using `tinyglobby` since it is not deterministic: moved the sort logic outside the if-else statement
- update react versions at tests: on my local I'm unable to pass and fix  `test/catalogRender.test.ts` tests (Windows laptop, check screenshot `running taze tests using Node 20.20.2` below); maybe we should add node 20 to the matrix until it is deprecated

### Linked Issues

fixes #254

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
**NOTE**: to run tests here using Node 20 we need latest version (I installed 20.20.2, using 20.10.0 missing export `styleText` from `node:utils`)

<details>
<summary>error running taze tests with Node 20.10.0</summary>

<img width="959" height="420" alt="error running taze tests with Node 20.10.0" src="https://github.com/user-attachments/assets/18ee5502-816b-436d-93b4-a9e1b72d9d03" />

</details>

<details>
<summary>running taze tests using Node 20.20.2</summary>

<img width="1052" height="699" alt="running taze tests using Node 20.20.2" src="https://github.com/user-attachments/assets/7d6c89f7-30fb-41dc-a1a6-7268e9d7c356" />

</details>

