### PR TITLE
test: add regression for beta hash ordering (#256)

### DIFF
--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -114,6 +114,16 @@ it('getMaxSatisfying', async () => {
     rc: '4.2.1-rc.3',
     experimental: '0.0.0-experimental-4508873393-20240430',
   }))
+
+  // #256
+  expect('1.0.0-beta.20').toBe(getMaxSatisfying([
+    '1.0.0-beta.19',
+    '1.0.0-beta.20',
+    '1.0.0-beta.9-e89174b',
+  ], '^1.0.0-beta.20', 'default', {
+    latest: '0.45.2',
+    beta: '1.0.0-beta.20',
+  }))
 }, 10_000)
 
 it('deprecated filter', () => {


### PR DESCRIPTION
## Description
Add a regression test for #256 showing that Taze currently treats `1.0.0-beta.9-e89174b` as newer than `1.0.0-beta.20`.