### PR TITLE
fix: updates locked version with a mature version

### DIFF
--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -111,6 +111,8 @@ export function getVersionOfRange(dep: ResolvedDepChange, range: RangeMode, opti
   if (filteredVersions.length === 0) {
     return undefined
   }
+  
+  dep.filteredVersions = filteredVersions
 
   return getMaxSatisfying(filteredVersions, dep.currentVersion, range, tags)
 }
@@ -143,7 +145,7 @@ export function updateTargetVersion(
     // - but this mode will always ignore the locked pkgs
     // - so we need to reset the target
     const { versions, time = {}, tags } = dep.pkgData
-    const targetVersion = getMaxSatisfying(versions, dep.currentVersion, 'minor', tags)
+    const targetVersion = getMaxSatisfying(dep.filteredVersions ?? versions, dep.currentVersion, 'minor', tags)
     if (targetVersion) {
       dep.targetVersion = targetVersion
       dep.targetVersionTime = time[dep.targetVersion]

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export interface ResolvedDepChange extends RawDep {
   resolveError?: Error | string | null
   aliasName?: string
   nodeCompatibleVersion?: { semver: string, compatible: boolean }
+  filteredVersions?: string[]
 }
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent'


### PR DESCRIPTION
### 🧭 Context

`taze` will update locked versions with immature versions.

Configuration used:
```
{
  "includeLocked": true,
  "maturityPeriod": 7
}
```

### 📚 Description

This PR does:
- store that `filteredVersions`(mature versions) array in the dependency
- re-use that `filteredVersions` array when updating the locked version

