### PR TITLE
fix: improve getMaxSatisfying logic to handle latest and next tags co…

### DIFF
--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -67,13 +67,13 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
   let version: string | null = null
 
   if (mode === 'latest') {
-    version = tags.latest
+    version = versions.includes(tags.latest) ? tags.latest : versions.at(-1) ?? null
   }
   else if (mode === 'newest') {
     version = versions.at(-1)!
   }
   else if (mode === 'next') {
-    version = tags.next
+    version = tags.next && versions.includes(tags.next) ? tags.next : versions.at(-1) ?? null
   }
   else if (mode === 'default' && (current === '*' || current.trim() === '')) {
     return

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -30,7 +30,7 @@ it('getVersionRange', () => {
 it('getMaxSatisfying', async () => {
   const { versions, tags } = await getPackageData('typescript')
   const latest = tags.latest
-  const newest = tags.next
+  const newest = versions.at(-1)
 
   // default
   expect(getMaxSatisfying(versions, '', 'default', tags)).toBeUndefined()
@@ -114,7 +114,42 @@ it('getMaxSatisfying', async () => {
     rc: '4.2.1-rc.3',
     experimental: '0.0.0-experimental-4508873393-20240430',
   }))
+
 }, 10_000)
+
+it('getMaxSatisfying - maturity period respects latest/next tags', () => {
+  // maturity period: latest tag filtered out -> fall back to newest in filtered list
+  expect('1.0.5').toBe(getMaxSatisfying(
+    ['1.0.4', '1.0.5'],
+    '^1.0.0',
+    'latest',
+    { latest: '1.0.6' }, // 1.0.6 too new, not in filtered list
+  ))
+
+  // maturity period: latest tag still in filtered list -> return it
+  expect('1.0.6').toBe(getMaxSatisfying(
+    ['1.0.4', '1.0.5', '1.0.6'],
+    '^1.0.0',
+    'latest',
+    { latest: '1.0.6' },
+  ))
+
+  // maturity period: next tag filtered out -> fall back to newest in filtered list
+  expect('1.0.5').toBe(getMaxSatisfying(
+    ['1.0.4', '1.0.5'],
+    '^1.0.0',
+    'next',
+    { next: '1.0.6' }, // 1.0.6 too new, not in filtered list
+  ))
+
+  // maturity period: next tag in filtered list -> return it
+  expect('1.0.6').toBe(getMaxSatisfying(
+    ['1.0.4', '1.0.5', '1.0.6'],
+    '^1.0.0',
+    'next',
+    { next: '1.0.6' },
+  ))
+})
 
 it('deprecated filter', () => {
   const versions = ['1.0.0', '1.1.0', '1.2.0', '2.0.0']


### PR DESCRIPTION
closes https://github.com/antfu-collective/taze/issues/262

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
