### PR TITLE
feat: add stable version mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ The filter when using the maturity-period flag is 7 days. You may also want to p
 taze --maturity-period 14
 ```
 
+If you want stable releases only while still honoring the maturity period, use `stable` mode.
+
+```bash
+taze stable --maturity-period 14
+```
+
 > [!NOTE]
 > This kind of filtering is sometimes called `cooldown` or `minimumReleaseAge` by other tools.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ import type { CheckOptions, CommonOptions } from './types'
 
 export const LOG_LEVELS = ['debug', 'info', 'warn', 'error', 'silent'] as const
 
-export const MODE_CHOICES = ['default', 'major', 'minor', 'patch', 'latest', 'newest', 'next'] as const
+export const MODE_CHOICES = ['default', 'major', 'minor', 'patch', 'latest', 'newest', 'stable', 'next'] as const
 
 export const DEFAULT_IGNORE_PATHS = [
   '**/node_modules/**',

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -27,7 +27,7 @@ export function getVersionRangePrefix(v: string) {
   return null
 }
 
-export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest' | 'newest' | 'next'>) {
+export function changeVersionRange(version: string, mode: Exclude<RangeMode, 'latest' | 'newest' | 'stable' | 'next'>) {
   if (!validRange(version))
     return null
 
@@ -74,6 +74,20 @@ export function getMaxSatisfying(versions: string[], current: string, mode: Rang
   }
   else if (mode === 'next') {
     version = tags.next
+  }
+  else if (mode === 'stable') {
+    const range = changeVersionRange(current, 'default')
+    if (!range)
+      return
+
+    versions
+      .filter(ver => !ver.includes('-'))
+      .forEach((ver) => {
+        if (satisfies(ver, range)) {
+          if (!version || gt(ver, version))
+            version = ver
+        }
+      })
   }
   else if (mode === 'default' && (current === '*' || current.trim() === '')) {
     return

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -103,7 +103,16 @@ it('resolveDependency', async () => {
   expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), options, filter)).update)
   expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), options, filter)).update)
 
+  options.mode = 'stable'
+  // stable
+  expect(false).toBe((await resolveDependency(makePkg(''), options, filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('*'), options, filter)).update)
+  expect(false).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkg('>4.0.0'), options, filter)).update)
+
   // include locked
+  options.mode = 'newest'
   options.includeLocked = true
   expect(true).toBe((await resolveDependency(makePkg('4.0.0'), options, filter)).update)
 

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -150,3 +150,20 @@ it('maturity period filter', () => {
   const noFilter = filterVersionsByMaturityPeriod(versions, time, 0)
   expect(noFilter).toEqual(versions)
 })
+
+it('stable mode should ignore prereleases and use filtered candidates', () => {
+  const versions = [
+    '1.0.0',
+    '1.1.0-beta.1',
+    '1.1.0',
+    '1.2.0-canary.1',
+  ]
+
+  const tags = {
+    latest: '1.2.0-canary.1',
+    next: '1.2.0-canary.1',
+  }
+
+  expect(getMaxSatisfying(versions, '^1.0.0', 'stable', tags)).toBe('1.1.0')
+  expect(getMaxSatisfying(versions, '~1.0.0', 'stable', tags)).toBe('1.0.0')
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/antfu-collective/ni/issues/338

### 🧭 Context

When using `maturityPeriod`:
- `mode: "newest"` respects maturity filtering, but can select prereleases (`-dev`, `-beta`, `-canary`).
- `mode: "latest"` is stable-oriented, but does not reliably satisfy the “stable + maturity” workflow.
This makes it hard to express: **“pick a stable version, but only if it is older than N days.”**

### What this PR changes

Adds a new `stable` mode.

`stable`:
- excludes prerelease versions,
- selects from filtered candidates (including maturity filtering),
- keeps existing behavior of other modes unchanged.

### Why
This provides an explicit mode for teams that want safer upgrades:
- no prerelease bumps,
- no very recent releases when `maturityPeriod` is set.

### Examples
```ts
export default defineConfig({
  mode: 'stable',
  maturityPeriod: 2,
})
```

```sh
taze stable --maturity-period 14
```