### PR TITLE
fix: respect maturity period in interactive mode

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 import readline from 'node:readline'
 import { createControlledPromise, notNullish } from '@antfu/utils'
 import c from 'ansis'
-import { getVersionOfRange, updateTargetVersion } from '../../io/resolves'
+import { getVersionOfRange, getVersionOfTag, updateTargetVersion } from '../../io/resolves'
 import { colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable } from '../../render'
 import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
@@ -145,7 +145,12 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
     const versions = Object.entries({
       minor: getVersionOfRange(dep, 'minor', options),
       patch: getVersionOfRange(dep, 'patch', options),
-      ...dep.pkgData.tags,
+      ...Object.fromEntries(
+        Object.keys(dep.pkgData.tags).map(tag => [
+          tag,
+          getVersionOfTag(dep, tag, options),
+        ]),
+      ),
     })
       .map(([name, version]) => {
         if (!version)

--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -96,8 +96,20 @@ export async function getPackageData(name: string, protocol: Protocol = 'npm', c
 }
 
 export function getVersionOfRange(dep: ResolvedDepChange, range: RangeMode, options: CheckOptions) {
-  const { versions, tags, deprecated, time } = dep.pkgData
+  const { tags } = dep.pkgData
+  const filteredVersions = getFilteredVersions(dep, options)
 
+  if (filteredVersions.length === 0) {
+    return undefined
+  }
+
+  dep.filteredVersions = filteredVersions
+
+  return getMaxSatisfying(filteredVersions, dep.currentVersion, range, tags)
+}
+
+export function getFilteredVersions(dep: ResolvedDepChange, options: CheckOptions) {
+  const { versions, deprecated, time } = dep.pkgData
   let filteredVersions = versions
 
   if (deprecated && Object.keys(deprecated).length > 0) {
@@ -108,13 +120,26 @@ export function getVersionOfRange(dep: ResolvedDepChange, range: RangeMode, opti
     filteredVersions = filterVersionsByMaturityPeriod(filteredVersions, time, options.maturityPeriod)
   }
 
-  if (filteredVersions.length === 0) {
-    return undefined
-  }
+  return filteredVersions
+}
 
+export function getVersionOfTag(dep: ResolvedDepChange, tag: string, options: CheckOptions) {
+  const version = dep.pkgData.tags[tag]
+  if (!version)
+    return undefined
+
+  if (tag === 'latest' || tag === 'next')
+    return getVersionOfRange(dep, tag, options)
+
+  const filteredVersions = dep.filteredVersions ?? getFilteredVersions(dep, options)
   dep.filteredVersions = filteredVersions
 
-  return getMaxSatisfying(filteredVersions, dep.currentVersion, range, tags)
+  return filteredVersions.includes(version) ? version : undefined
+}
+
+export function getLatestVersionAvailable(dep: ResolvedDepChange, targetVersion: string | SemVer, options: CheckOptions) {
+  const version = getVersionOfRange(dep, 'latest', options)
+  return version && gt(version, targetVersion) ? version : undefined
 }
 
 export function updateTargetVersion(
@@ -243,7 +268,7 @@ export async function resolveDependency(
   }
 
   const pkgData = await getPackageData(resolvedName, dep.protocol, options.cwd)
-  const { tags, error, deprecated } = pkgData
+  const { error, deprecated } = pkgData
 
   dep.pkgData = pkgData
   let err: Error | string | null = null
@@ -287,8 +312,8 @@ export async function resolveDependency(
 
   try {
     const targetVersion = minVersion(target || dep.targetVersion)
-    if (tags.latest && targetVersion && gt(tags.latest, targetVersion))
-      dep.latestVersionAvailable = tags.latest
+    if (targetVersion)
+      dep.latestVersionAvailable = getLatestVersionAvailable(dep, targetVersion, options)
 
     const { nodecompat = true } = options
     if (nodecompat) {

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -1,9 +1,9 @@
-import type { CheckOptions, DependencyFilter, RawDep } from '../src'
+import type { CheckOptions, DependencyFilter, RawDep, ResolvedDepChange } from '../src'
 import process from 'node:process'
 import { SemVer } from 'semver-es'
 import { expect, it } from 'vitest'
 import { resolveDependency } from '../src'
-import { getDiff } from '../src/io/resolves'
+import { getDiff, getLatestVersionAvailable, getVersionOfTag } from '../src/io/resolves'
 
 const filter: DependencyFilter = () => true
 
@@ -53,6 +53,34 @@ const options: CheckOptions = {
   mode: 'default',
   write: false,
   all: false,
+}
+
+function makeResolvedDepForMaturityPeriod(): ResolvedDepChange {
+  const now = new Date()
+  const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)
+
+  return {
+    name: 'test-package',
+    currentVersion: '^1.0.0',
+    source: 'dependencies',
+    update: true,
+    targetVersion: '^1.1.0',
+    diff: 'minor',
+    provenanceDowngraded: false,
+    pkgData: {
+      tags: {
+        latest: '1.2.0',
+        beta: '1.2.0',
+        stable: '1.1.0',
+      },
+      versions: ['1.0.0', '1.1.0', '1.2.0'],
+      time: {
+        '1.0.0': twoDaysAgo.toISOString(),
+        '1.1.0': twoDaysAgo.toISOString(),
+        '1.2.0': now.toISOString(),
+      },
+    },
+  }
 }
 
 it('resolveDependency', async () => {
@@ -187,4 +215,19 @@ it('getDiff', () => {
   expect(getDiff(new SemVer('1.2.3-a'), new SemVer('1.3.3-a'))).toBe('minor')
   expect(getDiff(new SemVer('1.2.3-a'), new SemVer('2.2.3-a'))).toBe('major')
   expect(getDiff(new SemVer('2.0.0-a'), new SemVer('2.0.0'))).toBe('patch')
+})
+
+it('filters interactive candidate versions by maturity period', () => {
+  const dep = makeResolvedDepForMaturityPeriod()
+  const maturityOptions = {
+    ...options,
+    maturityPeriod: 1,
+  }
+
+  expect(getLatestVersionAvailable(dep, '1.1.0', maturityOptions)).toBeUndefined()
+  expect(getLatestVersionAvailable(dep, '1.0.0', maturityOptions)).toBe('1.1.0')
+
+  expect(getVersionOfTag(dep, 'latest', maturityOptions)).toBe('1.1.0')
+  expect(getVersionOfTag(dep, 'stable', maturityOptions)).toBe('1.1.0')
+  expect(getVersionOfTag(dep, 'beta', maturityOptions)).toBeUndefined()
 })


### PR DESCRIPTION
### 🧭 Context

Closes #259.

`taze --maturity-period` already filters newly published versions during normal resolution, but `--interactive` could still surface versions outside the maturity window.

This mainly happened through `latestVersionAvailable` and raw dist-tag entries in the version picker. A package could be treated as up to date in normal mode, but still appear as an unchecked/selectable immature update in interactive mode.

This matters more now that package managers are tightening release-age checks. Recent pnpm 11.1.x releases strengthened `minimumReleaseAge` behavior, where pnpm now does more validation around cached metadata and lockfile entries, and in loose mode can persist immature picks into `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`. If taze proposes an immature version first, pnpm may either reject it or record a bypass that the user did not really intend to add.

### 📚 Description

This PR makes interactive mode use the same maturity/deprecation-filtered candidate set as the regular resolver.

The issue suggested adding a new `maturityPeriodStrict` option to hide immature versions from the interactive list, but my PR takes a smaller approach; when `maturityPeriod` is already configured, interactive mode should respect it consistently without needing another option.

Changes included:

- extract the filtered version calculation so it can be reused
- compute `latestVersionAvailable` from maturity-filtered versions instead of raw `tags.latest`
- resolve interactive dist-tag entries through the filtered candidate set
- preserve the existing `latest` / `next` fallback behavior, but only among eligible versions
- add regression coverage for mature and immature interactive candidates

This prevents interactive mode from suggesting or selecting package versions excluded by `--maturity-period`, while still showing valid mature alternatives when available.