### PR TITLE
feat: auto-infer maturityPeriod from pnpm/yarn workspace config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
-import type { CommonOptions } from './types'
+import type { CheckOptions, CommonOptions } from './types'
 import process from 'node:process'
 import { toArray } from '@antfu/utils'
 import _debug from 'debug'
 import deepmerge from 'deepmerge'
 import { createConfigLoader } from 'unconfig'
 import { DEFAULT_CHECK_OPTIONS } from './constants'
+import { detectMaturityPeriod } from './utils/detectMaturity'
 
 const debug = _debug('taze:config')
 
@@ -49,11 +50,22 @@ export async function resolveConfig(
 
   const config = await loader.load()
 
-  if (!config.sources.length)
-    return deepmerge(defaults, options)
+  let merged: CommonOptions
+  if (!config.sources.length) {
+    merged = deepmerge(defaults, options)
+  }
+  else {
+    debug(`config file found ${config.sources[0]}`)
+    const configOptions = normalizeConfig(config.config)
+    merged = deepmerge(deepmerge(defaults, configOptions), options)
+  }
 
-  debug(`config file found ${config.sources[0]}`)
-  const configOptions = normalizeConfig(config.config)
+  const checkMerged = merged as CheckOptions
+  if (checkMerged.maturityPeriod == null && !checkMerged.global) {
+    const detected = await detectMaturityPeriod(checkMerged.cwd || process.cwd())
+    if (detected != null)
+      checkMerged.maturityPeriod = detected
+  }
 
-  return deepmerge(deepmerge(defaults, configOptions), options)
+  return merged
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,5 +40,4 @@ export const DEFAULT_CHECK_OPTIONS: CheckOptions = {
   group: true,
   includeLocked: false,
   nodecompat: true,
-  maturityPeriod: 0,
 }

--- a/src/utils/detectMaturity.ts
+++ b/src/utils/detectMaturity.ts
@@ -1,0 +1,135 @@
+import { promises as fs } from 'node:fs'
+import _debug from 'debug'
+import { findUp } from 'find-up-simple'
+import { detect } from 'package-manager-detector'
+import { parsePnpmWorkspaceYaml } from 'pnpm-workspace-yaml'
+
+const debug = _debug('taze:config')
+
+// pnpm v11+ enables `minimumReleaseAge` by default at 1440 minutes (1 day).
+// See https://pnpm.io/settings#minimumreleaseage
+// Yarn 4.12+ enables `npmMinimalAgeGate` by default at "1d".
+const PNPM_DEFAULT_MAJOR = 11
+const YARN_DEFAULT_MAJOR = 4
+const YARN_DEFAULT_MINOR = 12
+const DEFAULT_DAYS = 1
+
+// Parse a Yarn DURATION value. Yarn's SettingsType.DURATION with
+// unit: MINUTES accepts either a bare number (minutes) or a string with
+// an optional unit suffix (d/h/m/s). Returns days, or undefined.
+export function parseYarnDuration(value: unknown): number | undefined {
+  if (typeof value === 'number')
+    return value > 0 ? value / 1440 : undefined
+  if (typeof value !== 'string')
+    return undefined
+  const m = value.trim().match(/^(\d+(?:\.\d+)?)\s*([dhms]?)$/i)
+  if (!m)
+    return undefined
+  const num = Number.parseFloat(m[1])
+  if (!Number.isFinite(num) || num <= 0)
+    return undefined
+  switch ((m[2] || 'm').toLowerCase()) {
+    case 'd': return num
+    case 'h': return num / 24
+    case 'm': return num / 1440
+    case 's': return num / 86400
+    default: return undefined
+  }
+}
+
+async function readYamlTop(filepath: string | undefined): Promise<Record<string, any> | null> {
+  if (!filepath)
+    return null
+  try {
+    const text = await fs.readFile(filepath, 'utf-8')
+    return parsePnpmWorkspaceYaml(text).getDocument().toJSON() as any
+  }
+  catch (e) {
+    debug(`failed to parse ${filepath}: ${e}`)
+    return null
+  }
+}
+
+function parseSemverParts(version: string | undefined): { major: number, minor: number } | null {
+  if (!version)
+    return null
+  const [majStr, minStr] = version.split('+')[0].split('.')
+  const major = Number.parseInt(majStr, 10)
+  const minor = Number.parseInt(minStr, 10)
+  if (!Number.isFinite(major))
+    return null
+  return { major, minor: Number.isFinite(minor) ? minor : 0 }
+}
+
+// Walk up to find the closest `packageManager` (or `devEngines.packageManager`)
+// declaration. Reuses package-manager-detector for the walk + per-directory
+// package.json lookup, capturing the raw version via its `packageJsonParser`
+// hook. The library's own `DetectResult.version` collapses yarn >= 2 to
+// "berry", so we snapshot the unprocessed value here.
+async function detectAgentAndVersion(cwd: string): Promise<{ name: string, version: string } | null> {
+  let matched: { name: string, version: string } | null = null
+  await detect({
+    cwd,
+    strategies: ['packageManager-field', 'devEngines-field'],
+    packageJsonParser(content) {
+      const pkg = JSON.parse(content)
+      if (!matched) {
+        if (typeof pkg?.packageManager === 'string') {
+          const at = pkg.packageManager.indexOf('@')
+          if (at > 0) {
+            matched = {
+              name: pkg.packageManager.slice(0, at),
+              version: pkg.packageManager.slice(at + 1),
+            }
+          }
+        }
+        else if (typeof pkg?.devEngines?.packageManager?.name === 'string') {
+          matched = {
+            name: pkg.devEngines.packageManager.name,
+            version: pkg.devEngines.packageManager.version ?? '',
+          }
+        }
+      }
+      return pkg
+    },
+  })
+  return matched
+}
+
+export async function detectMaturityPeriod(cwd: string): Promise<number | undefined> {
+  // 1. pnpm-workspace.yaml → minimumReleaseAge (minutes)
+  const pnpmYamlPath = await findUp('pnpm-workspace.yaml', { cwd })
+  const pnpmYaml = await readYamlTop(pnpmYamlPath)
+  if (pnpmYaml && typeof pnpmYaml.minimumReleaseAge === 'number' && pnpmYaml.minimumReleaseAge > 0) {
+    const days = pnpmYaml.minimumReleaseAge / 1440
+    debug(`maturityPeriod=${days}d from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m)`)
+    return days
+  }
+
+  // 2. .yarnrc.yml → npmMinimalAgeGate (duration)
+  const yarnYamlPath = await findUp('.yarnrc.yml', { cwd })
+  const yarnYaml = await readYamlTop(yarnYamlPath)
+  if (yarnYaml && yarnYaml.npmMinimalAgeGate != null) {
+    const days = parseYarnDuration(yarnYaml.npmMinimalAgeGate)
+    if (days != null) {
+      debug(`maturityPeriod=${days}d from ${yarnYamlPath} (npmMinimalAgeGate=${JSON.stringify(yarnYaml.npmMinimalAgeGate)})`)
+      return days
+    }
+  }
+
+  // 3. packageManager defaults via package-manager-detector
+  const agent = await detectAgentAndVersion(cwd)
+  const parts = parseSemverParts(agent?.version)
+  if (agent && parts) {
+    if (agent.name === 'pnpm' && parts.major >= PNPM_DEFAULT_MAJOR) {
+      debug(`maturityPeriod=${DEFAULT_DAYS}d from detected ${agent.name}@${agent.version}`)
+      return DEFAULT_DAYS
+    }
+    if (agent.name === 'yarn' && (parts.major > YARN_DEFAULT_MAJOR || (parts.major === YARN_DEFAULT_MAJOR && parts.minor >= YARN_DEFAULT_MINOR))) {
+      debug(`maturityPeriod=${DEFAULT_DAYS}d from detected ${agent.name}@${agent.version}`)
+      return DEFAULT_DAYS
+    }
+  }
+
+  return undefined
+}

--- a/test/maturityDetection.test.ts
+++ b/test/maturityDetection.test.ts
@@ -1,0 +1,219 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { detectMaturityPeriod, parseYarnDuration } from '../src/utils/detectMaturity'
+
+const tmpRoots: string[] = []
+
+function makeTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'taze-maturity-'))
+  tmpRoots.push(dir)
+  return dir
+}
+
+function write(dir: string, relpath: string, content: string) {
+  const full = path.join(dir, relpath)
+  fs.mkdirSync(path.dirname(full), { recursive: true })
+  fs.writeFileSync(full, content, 'utf-8')
+}
+
+afterAll(() => {
+  for (const dir of tmpRoots)
+    fs.rmSync(dir, { recursive: true, force: true })
+})
+
+describe('parseYarnDuration', () => {
+  it('handles duration strings with unit suffix', () => {
+    expect(parseYarnDuration('1d')).toBe(1)
+    expect(parseYarnDuration('3d')).toBe(3)
+    expect(parseYarnDuration('24h')).toBe(1)
+    expect(parseYarnDuration('60m')).toBe(60 / 1440)
+    expect(parseYarnDuration('86400s')).toBe(1)
+    expect(parseYarnDuration('0.5d')).toBe(0.5)
+  })
+
+  it('treats bare numeric strings as minutes', () => {
+    expect(parseYarnDuration('1440')).toBe(1)
+  })
+
+  it('treats raw numbers as minutes', () => {
+    expect(parseYarnDuration(1440)).toBe(1)
+    expect(parseYarnDuration(720)).toBe(0.5)
+  })
+
+  it('returns undefined for non-positive or invalid input', () => {
+    expect(parseYarnDuration('0')).toBeUndefined()
+    expect(parseYarnDuration(0)).toBeUndefined()
+    expect(parseYarnDuration(-1)).toBeUndefined()
+    expect(parseYarnDuration('abc')).toBeUndefined()
+    expect(parseYarnDuration('')).toBeUndefined()
+    expect(parseYarnDuration('1y')).toBeUndefined()
+    expect(parseYarnDuration(null)).toBeUndefined()
+    expect(parseYarnDuration(undefined)).toBeUndefined()
+    expect(parseYarnDuration({})).toBeUndefined()
+  })
+})
+
+describe('detectMaturityPeriod', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = makeTmp()
+  })
+
+  describe('pnpm-workspace.yaml', () => {
+    it('reads minimumReleaseAge (minutes -> days)', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 1440\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('supports fractional days from sub-day minutes', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 720\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(0.5)
+    })
+
+    it('falls through when minimumReleaseAge is 0', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 0\n')
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('falls through when the yaml exists without the field', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'packages:\n  - "!**/test/**"\n')
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+  })
+
+  describe('.yarnrc.yml', () => {
+    it('reads npmMinimalAgeGate as a duration string', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "3d"\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(3)
+    })
+
+    it('reads npmMinimalAgeGate as 60m', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "60m"\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(60 / 1440)
+    })
+
+    it('reads npmMinimalAgeGate as a bare number (minutes)', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: 1440\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('falls through when the yaml exists without the field', async () => {
+      write(cwd, '.yarnrc.yml', 'nodeLinker: node-modules\n')
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+  })
+
+  describe('priority between sources', () => {
+    it('pnpm-workspace.yaml wins over .yarnrc.yml when both have explicit values', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 2880\n')
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "5d"\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(2)
+    })
+
+    it('.yarnrc.yml wins over packageManager default', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "3d"\n')
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBe(3)
+    })
+
+    it('falls through pnpm yaml absent value to yarn yaml explicit value', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'packages:\n  - "!**/test/**"\n')
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "3d"\n')
+      expect(await detectMaturityPeriod(cwd)).toBe(3)
+    })
+  })
+
+  describe('packageManager defaults', () => {
+    it('applies pnpm@11 default (1 day)', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('tolerates pnpm hash suffix in packageManager', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.2.0+sha512.abc' }))
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('returns undefined for pnpm@10', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@10.33.4' }))
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('applies yarn@4.12 default', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@4.12.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('returns undefined for yarn@4.11', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@4.11.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('applies yarn@5 default (above threshold)', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@5.0.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('returns undefined for yarn@3', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@3.6.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('returns undefined when packageManager is absent', async () => {
+      write(cwd, 'package.json', JSON.stringify({ name: 'demo' }))
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('returns undefined when no package.json exists upstream', async () => {
+      // tmp dir under /tmp doesn't have a package.json walking up to /
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('returns undefined for non-pnpm/yarn package managers', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'npm@11.0.0' }))
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
+    it('reads devEngines.packageManager when packageManager field is absent', async () => {
+      write(cwd, 'package.json', JSON.stringify({
+        devEngines: { packageManager: { name: 'pnpm', version: '11.0.0' } },
+      }))
+      expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+  })
+
+  describe('walk-up behavior', () => {
+    it('finds pnpm-workspace.yaml above cwd', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 1440\n')
+      const deep = path.join(cwd, 'packages', 'foo', 'src')
+      fs.mkdirSync(deep, { recursive: true })
+      expect(await detectMaturityPeriod(deep)).toBe(1)
+    })
+
+    it('finds .yarnrc.yml above cwd', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "2d"\n')
+      const deep = path.join(cwd, 'apps', 'web')
+      fs.mkdirSync(deep, { recursive: true })
+      expect(await detectMaturityPeriod(deep)).toBe(2)
+    })
+
+    it('walks past a sub-package package.json without packageManager to the monorepo root', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      const leafDir = path.join(cwd, 'packages', 'foo')
+      write(leafDir, 'package.json', JSON.stringify({ name: '@demo/foo' }))
+      expect(await detectMaturityPeriod(leafDir)).toBe(1)
+    })
+
+    it('uses the closest packageManager declaration when nested', async () => {
+      // outer says pnpm@11 (1 day), inner says yarn@4.11 (undefined)
+      // we expect inner to win since walk-up stops at the first packageManager match
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      const inner = path.join(cwd, 'sub')
+      write(inner, 'package.json', JSON.stringify({ packageManager: 'yarn@4.11.0' }))
+      expect(await detectMaturityPeriod(inner)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Auto-applies `maturityPeriod` (the maturity-period / cooldown filter) from project-level configuration when the user hasn't set it explicitly, so taze respects the same intent already declared for the package manager:

- Reads `minimumReleaseAge` (minutes) from `pnpm-workspace.yaml`.
- Reads `npmMinimalAgeGate` (duration string like `"3d"` / `"60m"`) from `.yarnrc.yml`.
- Falls back to the package manager's own default (1 day) when `packageManager` is `pnpm@>=11` or `yarn@>=4.12`, using `package-manager-detector` to walk up the directory tree (so it works from sub-packages of a monorepo). CLI flag and `taze.config.*` still win when set.

## Test plan

- [x] `pnpm vitest run test/maturityDetection.test.ts` — 30 new tests covering the duration parser, both YAML readers, walk-up behavior, all priority cases, and `devEngines.packageManager`.
- [x] `pnpm lint` and `pnpm typecheck` clean.
- [x] Smoke tested end-to-end through `resolveConfig` across 8 scenarios (yaml, packageManager defaults, CLI override, explicit `0` disabling detection, `--global` skip, sub-dir walk-up).