### PR TITLE
feat: respect package manager maturity exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ The filter when using the maturity-period flag is 7 days. You may also want to p
 taze --maturity-period 14
 ```
 
+You can exclude packages from the maturity filter. This is also inferred from package manager config when available, such as `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` and `npmPreapprovedPackages` in `.yarnrc.yml`.
+
+```bash
+taze --maturity-period-exclude react,webpack
+```
+
 If you want stable releases only while still honoring the maturity period, use `stable` mode.
 
 ```bash
@@ -137,6 +143,11 @@ export default defineConfig({
     // regex starts and ends with '/'
     '/vue/': 'latest'
   },
+  // exclude packages from the maturity period filter
+  maturityPeriodExclude: [
+    'react',
+    '@myorg/*',
+  ],
   // disable checking for "overrides" package.json field
   depFields: {
     overrides: false

--- a/schema.json
+++ b/schema.json
@@ -165,6 +165,13 @@
       "description": "Wait period in days before upgrading to newly released packages. Helps avoid potentially malicious packages released recently.",
       "default": 0
     },
+    "maturityPeriodExclude": {
+      "description": "Dependencies to exclude from the maturity period filter. Accepts a single pattern or a list.",
+      "anyOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
+    },
     "concurrency": {
       "type": "integer",
       "minimum": 1,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ cli
   .option('--nodecompat', 'show package compatibility with current node version')
   .option('--peer', 'Include peerDependencies in the update process')
   .option('--maturity-period [days]', 'wait period in days before upgrading to newly released packages (default: 7 when flag is used, 0 when not used)')
+  .option('--maturity-period-exclude <deps>', 'dependencies to exclude from the maturity period filter')
   .option('--concurrency <requests>', 'number of concurrent requests when resolving dependencies', { default: 10 })
   .action(async (mode: RangeMode | undefined, options: Partial<CheckOptions>) => {
     if (mode) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import _debug from 'debug'
 import deepmerge from 'deepmerge'
 import { createConfigLoader } from 'unconfig'
 import { DEFAULT_CHECK_OPTIONS } from './constants'
-import { detectMaturityPeriod } from './utils/detectMaturity'
+import { detectMaturityConfig } from './utils/detectMaturity'
 
 const debug = _debug('taze:config')
 
@@ -14,9 +14,11 @@ function normalizeConfig(options: CommonOptions) {
   if ('default' in options)
     options = options.default as CommonOptions
 
+  const checkOptions = options as CheckOptions
   options.ignorePaths = toArray(options.ignorePaths)
   options.exclude = toArray(options.exclude)
   options.include = toArray(options.include)
+  checkOptions.maturityPeriodExclude = toArray(checkOptions.maturityPeriodExclude)
 
   if (options.silent)
     options.loglevel = 'silent'
@@ -61,10 +63,12 @@ export async function resolveConfig(
   }
 
   const checkMerged = merged as CheckOptions
-  if (checkMerged.maturityPeriod == null && !checkMerged.global) {
-    const detected = await detectMaturityPeriod(checkMerged.cwd || process.cwd())
-    if (detected != null)
-      checkMerged.maturityPeriod = detected
+  if (!checkMerged.global && (checkMerged.maturityPeriod == null || !checkMerged.maturityPeriodExclude?.length)) {
+    const detected = await detectMaturityConfig(checkMerged.cwd || process.cwd())
+    if (checkMerged.maturityPeriod == null && detected?.maturityPeriod != null)
+      checkMerged.maturityPeriod = detected.maturityPeriod
+    if (!checkMerged.maturityPeriodExclude?.length && detected?.maturityPeriodExclude.length)
+      checkMerged.maturityPeriodExclude = detected.maturityPeriodExclude
   }
 
   return merged

--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -8,7 +8,7 @@ import _debug from 'debug'
 import { resolve } from 'pathe'
 import { eq, gt, lt, minVersion, satisfies } from 'semver-es'
 import { diffSorter } from '../filters/diff-sorter'
-import { getPackageMode } from '../utils/config'
+import { getMaturityPeriodExcludeRanges, getPackageMode, isVersionMaturityPeriodExcluded } from '../utils/config'
 import { queueContext } from '../utils/context'
 import { parsePnpmPackagePath, parseYarnPackagePath } from '../utils/package'
 import { fetchJsrPackageMeta, fetchPackage } from '../utils/packument'
@@ -116,8 +116,18 @@ export function getFilteredVersions(dep: ResolvedDepChange, options: CheckOption
     filteredVersions = filterDeprecatedVersions(filteredVersions, deprecated)
   }
 
-  if (options.maturityPeriod && options.maturityPeriod > 0) {
-    filteredVersions = filterVersionsByMaturityPeriod(filteredVersions, time, options.maturityPeriod)
+  const maturityPeriodExclude = getMaturityPeriodExcludeRanges(dep.name, options)
+  if (options.maturityPeriod && options.maturityPeriod > 0 && maturityPeriodExclude !== true) {
+    const maturityCandidates = filteredVersions
+    filteredVersions = filterVersionsByMaturityPeriod(maturityCandidates, time, options.maturityPeriod)
+
+    if (maturityPeriodExclude.length > 0) {
+      const filteredVersionSet = new Set(filteredVersions)
+      filteredVersions = maturityCandidates.filter(version =>
+        filteredVersionSet.has(version)
+        || isVersionMaturityPeriodExcluded(version, maturityPeriodExclude),
+      )
+    }
   }
 
   return filteredVersions

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,10 @@ export interface CheckOptions extends CommonOptions {
    * @default 0 (no waiting period)
    */
   maturityPeriod?: number
+  /**
+   * Dependencies that bypass the maturity period filter
+   */
+  maturityPeriodExclude?: string | string[]
 }
 
 interface BasePackageMeta {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,6 @@
 import type { CheckOptions } from '../types'
+import { toArray } from '@antfu/utils'
+import { satisfies } from 'semver-es'
 import { filterToRegex } from './dependenciesFilter'
 
 export function getPackageMode(pkgName: string, options: CheckOptions) {
@@ -11,4 +13,42 @@ export function getPackageMode(pkgName: string, options: CheckOptions) {
       return options.packageMode[name]
   }
   return undefined
+}
+
+export function getMaturityPeriodExcludeRanges(pkgName: string, options: CheckOptions): true | string[] {
+  const ranges: string[] = []
+
+  for (const selector of toArray(options.maturityPeriodExclude).flatMap(item => item.split(','))) {
+    const trimmed = selector.trim()
+    if (!trimmed)
+      continue
+
+    const versionSeparatorIndex = trimmed.startsWith('/') ? -1 : trimmed.lastIndexOf('@')
+    const name = versionSeparatorIndex > 0 ? trimmed.slice(0, versionSeparatorIndex) : trimmed
+
+    if (!filterToRegex(name).test(pkgName))
+      continue
+
+    if (versionSeparatorIndex <= 0)
+      return true
+
+    const versionRanges = trimmed
+      .slice(versionSeparatorIndex + 1)
+      .split('||')
+      .map(range => range.trim())
+      .filter(Boolean)
+
+    ranges.push(...versionRanges)
+  }
+
+  return ranges
+}
+
+export function isVersionMaturityPeriodExcluded(version: string, ranges: string[]) {
+  for (const range of ranges) {
+    if (satisfies(version, range, { includePrerelease: true }))
+      return true
+  }
+
+  return false
 }

--- a/src/utils/detectMaturity.ts
+++ b/src/utils/detectMaturity.ts
@@ -14,6 +14,11 @@ const YARN_DEFAULT_MAJOR = 4
 const YARN_DEFAULT_MINOR = 12
 const DEFAULT_DAYS = 1
 
+export interface DetectedMaturityConfig {
+  maturityPeriod?: number
+  maturityPeriodExclude: string[]
+}
+
 // Parse a Yarn DURATION value. Yarn's SettingsType.DURATION with
 // unit: MINUTES accepts either a bare number (minutes) or a string with
 // an optional unit suffix (d/h/m/s). Returns days, or undefined.
@@ -48,6 +53,13 @@ async function readYamlTop(filepath: string | undefined): Promise<Record<string,
     debug(`failed to parse ${filepath}: ${e}`)
     return null
   }
+}
+
+function readStringList(value: unknown): string[] {
+  if (!Array.isArray(value))
+    return []
+
+  return value.filter((item): item is string => typeof item === 'string')
 }
 
 function parseSemverParts(version: string | undefined): { major: number, minor: number } | null {
@@ -96,24 +108,26 @@ async function detectAgentAndVersion(cwd: string): Promise<{ name: string, versi
   return matched
 }
 
-export async function detectMaturityPeriod(cwd: string): Promise<number | undefined> {
+export async function detectMaturityConfig(cwd: string): Promise<DetectedMaturityConfig | undefined> {
   // 1. pnpm-workspace.yaml → minimumReleaseAge (minutes)
   const pnpmYamlPath = await findUp('pnpm-workspace.yaml', { cwd })
   const pnpmYaml = await readYamlTop(pnpmYamlPath)
+  const pnpmExclude = readStringList(pnpmYaml?.minimumReleaseAgeExclude)
   if (pnpmYaml && typeof pnpmYaml.minimumReleaseAge === 'number' && pnpmYaml.minimumReleaseAge > 0) {
     const days = pnpmYaml.minimumReleaseAge / 1440
-    debug(`maturityPeriod=${days}d from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m)`)
-    return days
+    debug(`maturityPeriod=${days}d from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m, minimumReleaseAgeExclude=${JSON.stringify(pnpmExclude)})`)
+    return { maturityPeriod: days, maturityPeriodExclude: pnpmExclude }
   }
 
   // 2. .yarnrc.yml → npmMinimalAgeGate (duration)
   const yarnYamlPath = await findUp('.yarnrc.yml', { cwd })
   const yarnYaml = await readYamlTop(yarnYamlPath)
+  const yarnExclude = readStringList(yarnYaml?.npmPreapprovedPackages)
   if (yarnYaml && yarnYaml.npmMinimalAgeGate != null) {
     const days = parseYarnDuration(yarnYaml.npmMinimalAgeGate)
     if (days != null) {
-      debug(`maturityPeriod=${days}d from ${yarnYamlPath} (npmMinimalAgeGate=${JSON.stringify(yarnYaml.npmMinimalAgeGate)})`)
-      return days
+      debug(`maturityPeriod=${days}d from ${yarnYamlPath} (npmMinimalAgeGate=${JSON.stringify(yarnYaml.npmMinimalAgeGate)}, npmPreapprovedPackages=${JSON.stringify(yarnExclude)})`)
+      return { maturityPeriod: days, maturityPeriodExclude: yarnExclude }
     }
   }
 
@@ -123,13 +137,20 @@ export async function detectMaturityPeriod(cwd: string): Promise<number | undefi
   if (agent && parts) {
     if (agent.name === 'pnpm' && parts.major >= PNPM_DEFAULT_MAJOR) {
       debug(`maturityPeriod=${DEFAULT_DAYS}d from detected ${agent.name}@${agent.version}`)
-      return DEFAULT_DAYS
+      return { maturityPeriod: DEFAULT_DAYS, maturityPeriodExclude: pnpmExclude }
     }
     if (agent.name === 'yarn' && (parts.major > YARN_DEFAULT_MAJOR || (parts.major === YARN_DEFAULT_MAJOR && parts.minor >= YARN_DEFAULT_MINOR))) {
       debug(`maturityPeriod=${DEFAULT_DAYS}d from detected ${agent.name}@${agent.version}`)
-      return DEFAULT_DAYS
+      return { maturityPeriod: DEFAULT_DAYS, maturityPeriodExclude: yarnExclude }
     }
   }
 
+  if (pnpmExclude.length > 0 || yarnExclude.length > 0)
+    return { maturityPeriodExclude: [...pnpmExclude, ...yarnExclude] }
+
   return undefined
+}
+
+export async function detectMaturityPeriod(cwd: string): Promise<number | undefined> {
+  return (await detectMaturityConfig(cwd))?.maturityPeriod
 }

--- a/test/maturityDetection.test.ts
+++ b/test/maturityDetection.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
-import { detectMaturityPeriod, parseYarnDuration } from '../src/utils/detectMaturity'
+import { detectMaturityConfig, detectMaturityPeriod, parseYarnDuration } from '../src/utils/detectMaturity'
 
 const tmpRoots: string[] = []
 
@@ -73,6 +73,14 @@ describe('detectMaturityPeriod', () => {
       expect(await detectMaturityPeriod(cwd)).toBe(0.5)
     })
 
+    it('reads minimumReleaseAgeExclude', async () => {
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 1440\nminimumReleaseAgeExclude:\n  - react\n  - "@myorg/*"\n')
+      expect(await detectMaturityConfig(cwd)).toEqual({
+        maturityPeriod: 1,
+        maturityPeriodExclude: ['react', '@myorg/*'],
+      })
+    })
+
     it('falls through when minimumReleaseAge is 0', async () => {
       write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 0\n')
       expect(await detectMaturityPeriod(cwd)).toBeUndefined()
@@ -98,6 +106,14 @@ describe('detectMaturityPeriod', () => {
     it('reads npmMinimalAgeGate as a bare number (minutes)', async () => {
       write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: 1440\n')
       expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('reads npmPreapprovedPackages', async () => {
+      write(cwd, '.yarnrc.yml', 'npmMinimalAgeGate: "1d"\nnpmPreapprovedPackages:\n  - react\n  - "@myorg/*"\n')
+      expect(await detectMaturityConfig(cwd)).toEqual({
+        maturityPeriod: 1,
+        maturityPeriodExclude: ['react', '@myorg/*'],
+      })
     })
 
     it('falls through when the yaml exists without the field', async () => {
@@ -132,6 +148,15 @@ describe('detectMaturityPeriod', () => {
       expect(await detectMaturityPeriod(cwd)).toBe(1)
     })
 
+    it('applies pnpm@11 default with minimumReleaseAgeExclude', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAgeExclude:\n  - react\n')
+      expect(await detectMaturityConfig(cwd)).toEqual({
+        maturityPeriod: 1,
+        maturityPeriodExclude: ['react'],
+      })
+    })
+
     it('tolerates pnpm hash suffix in packageManager', async () => {
       write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.2.0+sha512.abc' }))
       expect(await detectMaturityPeriod(cwd)).toBe(1)
@@ -145,6 +170,15 @@ describe('detectMaturityPeriod', () => {
     it('applies yarn@4.12 default', async () => {
       write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@4.12.0' }))
       expect(await detectMaturityPeriod(cwd)).toBe(1)
+    })
+
+    it('applies yarn@4.12 default with npmPreapprovedPackages', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'yarn@4.12.0' }))
+      write(cwd, '.yarnrc.yml', 'npmPreapprovedPackages:\n  - react\n')
+      expect(await detectMaturityConfig(cwd)).toEqual({
+        maturityPeriod: 1,
+        maturityPeriodExclude: ['react'],
+      })
     })
 
     it('returns undefined for yarn@4.11', async () => {

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -231,3 +231,26 @@ it('filters interactive candidate versions by maturity period', () => {
   expect(getVersionOfTag(dep, 'stable', maturityOptions)).toBe('1.1.0')
   expect(getVersionOfTag(dep, 'beta', maturityOptions)).toBeUndefined()
 })
+
+it('excludes packages from the maturity period filter', () => {
+  const maturityOptions = {
+    ...options,
+    maturityPeriod: 1,
+    maturityPeriodExclude: ['test-*'],
+  }
+
+  expect(getLatestVersionAvailable(makeResolvedDepForMaturityPeriod(), '1.1.0', maturityOptions)).toBe('1.2.0')
+  expect(getVersionOfTag(makeResolvedDepForMaturityPeriod(), 'latest', maturityOptions)).toBe('1.2.0')
+  expect(getVersionOfTag(makeResolvedDepForMaturityPeriod(), 'beta', maturityOptions)).toBe('1.2.0')
+})
+
+it('excludes package versions from the maturity period filter', () => {
+  const maturityOptions = {
+    ...options,
+    maturityPeriod: 1,
+    maturityPeriodExclude: ['test-package@1.2.0'],
+  }
+
+  expect(getVersionOfTag(makeResolvedDepForMaturityPeriod(), 'latest', maturityOptions)).toBe('1.2.0')
+  expect(getVersionOfTag(makeResolvedDepForMaturityPeriod(), 'beta', maturityOptions)).toBe('1.2.0')
+})


### PR DESCRIPTION
### 🔗 Linked issue

Closes #270.

### 🧭 Context

With version 19.13.0, `taze` can now infer `maturityPeriod` from package manager config, such as PNPM’s `minimumReleaseAge` and Yarn’s `npmMinimalAgeGate`. However, it didn’t also infer the matching exclusion settings. This meant packages listed in PNPM’s `minimumReleaseAgeExclude` or Yarn’s `npmPreapprovedPackages` were still filtered out by `taze`, even though the package manager itself would allow them to update immediately.

### 📚 Description

This PR adds support for maturity-period exclusions.

Changes included:

- add a `maturityPeriodExclude` config / CLI option
- infer exclusions from `pnpm-workspace.yaml` `minimumReleaseAgeExclude`
- infer exclusions from `.yarnrc.yml` `npmPreapprovedPackages`
- skip the maturity filter for excluded packages
- support package patterns and PNPM-style version-scoped exclusions
- update the config schema and README
- add regression coverage for detected config and filtered resolver behavior

With this change, `taze` follows the package manager’s maturity exclusions instead of applying the inferred age gate to every package unconditionally.