### PR TITLE
fix: keep version selector visible

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -6,7 +6,7 @@ import readline from 'node:readline'
 import { createControlledPromise, notNullish } from '@antfu/utils'
 import c from 'ansis'
 import { getVersionOfRange, getVersionOfTag, updateTargetVersion } from '../../io/resolves'
-import { colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable } from '../../render'
+import { colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable, sliceRenderLines } from '../../render'
 import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
 import { getPrefixedVersion } from '../../utils/versions'
@@ -171,20 +171,35 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
     return {
       render() {
         console.clear()
-        console.log(`${FIG_BLOCK} ${c.gray`Select a version for ${c.green.bold(dep.name)}${c.gray` (current ${dep.currentVersion})`}`}`)
-        console.log()
-        console.log(
-          formatTable(versions.map((v, idx) => {
-            return [
-              (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
-              timediff ? timeDifference(dep.currentVersionTime) : '',
-              c.gray(dep.currentVersion),
-              c.dim.gray('→'),
-              colorizeVersionDiff(dep.currentVersion, v.targetVersion),
-              timediff ? timeDifference(v.time) : '',
-            ]
-          }), 'LLLL').join('\n'),
-        )
+        const headerLines = [
+          `${FIG_BLOCK} ${c.gray`Select a version for ${c.green.bold(dep.name)}${c.gray` (current ${dep.currentVersion})`}`}`,
+          '',
+        ]
+        const versionRows = versions.map((v, idx) => {
+          return [
+            (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
+            timediff ? timeDifference(dep.currentVersionTime) : '',
+            c.gray(dep.currentVersion),
+            c.dim.gray('→'),
+            colorizeVersionDiff(dep.currentVersion, v.targetVersion),
+            timediff ? timeDifference(v.time) : '',
+          ]
+        })
+        const versionLines = formatTable(
+          versionRows,
+          'LLLL',
+        ).map(content => ({ content }))
+        let {
+          rows: remainHeight,
+          columns: availableWidth,
+        } = process.stdout
+
+        remainHeight -= headerLines.length + 1
+
+        headerLines.forEach(line => console.log(line))
+        const slice = sliceRenderLines(versionLines, index, remainHeight, availableWidth)
+
+        console.log(slice.map(line => line.content).join('\n'))
       },
       onKey(key) {
         switch (key.name) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -111,9 +111,39 @@ export function colorizeVersionDiff(from: string, to: string, hightlightRange = 
     + c[color](partsToColor.slice(i).join('.')).trim()
 }
 
-interface SliceRenderLine {
+export interface SliceRenderLine {
   content: string
   fixed?: boolean
+}
+
+export function sliceRenderLines(
+  lines: SliceRenderLine[],
+  focusedLineIndex: number,
+  remainHeight: number,
+  availableWidth: number,
+) {
+  const hasWrappedLines = lines.some((line) => {
+    const visualLineCount = Math.ceil(visualLength(line.content) / availableWidth)
+
+    return visualLineCount > 1
+  })
+
+  if (
+    remainHeight < 1
+    || lines.length === 0
+    || lines.length <= remainHeight
+    || hasWrappedLines
+  ) {
+    return lines
+  }
+
+  const half = Math.floor((remainHeight - 1) / 2)
+  const startOffset = focusedLineIndex - half
+  const endOffset = focusedLineIndex + remainHeight - half - lines.length
+  const compensatedStartOffset = endOffset <= 0 ? startOffset : startOffset - endOffset
+  const start = Math.max(0, compensatedStartOffset)
+
+  return lines.slice(start, start + remainHeight)
 }
 
 export function createSliceRender() {
@@ -159,26 +189,11 @@ export function createSliceRender() {
 
         if (depIndex === selectedDepIndex)
           break
-        else
-          focusedLineIndex += 1
+
+        focusedLineIndex += 1
       }
 
-      let slice: SliceRenderLine[]
-      if (
-        remainHeight < 1
-        || remainLines.length === 0
-        || remainLines.length <= remainHeight
-        || remainLines.some(x => Math.ceil(visualLength(x.content) / availableWidth) > 1)
-      ) {
-        slice = remainLines
-      }
-      else {
-        const half = Math.floor((remainHeight - 1) / 2)
-        const f = focusedLineIndex - half
-        const b = focusedLineIndex + remainHeight - half - remainLines.length
-        const start = Math.max(0, b <= 0 ? f : f - b)
-        slice = remainLines.slice(start, start + remainHeight)
-      }
+      const slice = sliceRenderLines(remainLines, focusedLineIndex, remainHeight, availableWidth)
 
       console.log(slice.map(x => x.content).join('\n'))
     },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,7 +5,7 @@ import { expect, it } from 'vitest'
 it('taze cli should just works', async () => {
   const binPath = resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await exec(process.execPath, [binPath], { throwOnError: false })
+  const proc = await exec(process.execPath, [binPath, '--help'], { throwOnError: false })
 
   expect(proc.stderr).toBe('')
   expect(proc.exitCode).toBe(0)
@@ -14,7 +14,7 @@ it('taze cli should just works', async () => {
 it('taze cli should accept --concurrency option', async () => {
   const binPath = resolve(__dirname, '../bin/taze.mjs')
 
-  const proc = await exec(process.execPath, [binPath, '--concurrency', '5'], { throwOnError: false })
+  const proc = await exec(process.execPath, [binPath, '--help', '--concurrency', '5'], { throwOnError: false })
 
   expect(proc.stderr).toBe('')
   expect(proc.exitCode).toBe(0)

--- a/test/packageConfig.test.ts
+++ b/test/packageConfig.test.ts
@@ -1,9 +1,41 @@
 import type { CheckOptions, CommonOptions, ResolvedDepChange } from '../src'
 import process from 'node:process'
 import { join } from 'pathe'
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 import { CheckPackages } from '../src'
 import { resolveConfig } from '../src/config'
+import * as packument from '../src/utils/packument'
+
+vi.spyOn(packument, 'fetchPackage').mockImplementation(async (name: string) => {
+  const packages: Record<string, { tags: Record<string, string>, versions: string[] }> = {
+    'express': {
+      tags: { latest: '5.1.0' },
+      versions: ['4.1.0', '4.19.2', '5.1.0'],
+    },
+    'typescript': {
+      tags: { latest: '6.0.3' },
+      versions: ['0.22.6', '6.0.3'],
+    },
+    'vite': {
+      tags: { latest: '6.0.0' },
+      versions: ['2.1.0', '6.0.0'],
+    },
+    'vue': {
+      tags: { latest: '3.5.34' },
+      versions: ['3.4.0', '3.5.34'],
+    },
+    'vue-router': {
+      tags: { latest: '4.6.4' },
+      versions: ['4.0.2', '4.6.4'],
+    },
+  }
+
+  return packages[name] ?? { tags: { latest: '1.0.0' }, versions: ['1.0.0'] }
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
 
 function getPkgInfo(name: string, result: ResolvedDepChange[]) {
   return result.filter(r => r.name === name)[0]

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,5 +1,5 @@
-import { expect, it } from 'vitest'
-import { formatTable } from '../src/render'
+import { describe, expect, it } from 'vitest'
+import { formatTable, sliceRenderLines } from '../src/render'
 
 it('formatTable', () => {
   expect(
@@ -13,4 +13,20 @@ it('formatTable', () => {
       "hello     hi  foobar",
     ]
   `)
+})
+
+describe(sliceRenderLines, () => {
+  it('keeps the focused line visible when slicing long lists', () => {
+    const lines = Array.from({ length: 12 }, (_, index) => ({ content: `version-${index}` }))
+
+    const slice = sliceRenderLines(lines, 8, 4, 80)
+    const contents = slice.map(line => line.content)
+
+    expect(contents).toStrictEqual([
+      'version-7',
+      'version-8',
+      'version-9',
+      'version-10',
+    ])
+  })
 })


### PR DESCRIPTION
### 🧭 Context

The interactive version selector could scroll the active item out of view when the list of candidate versions was longer than the available terminal height.

### 📚 Description

The interactive selector now slices long version lists around the currently focused row instead of always rendering from the top of the list. This keeps the active npm tag or version choice visible while moving through the menu.

Also, this PR updates the affected tests to avoid relying on live registry responses.

The branch does not change dependency resolution behaviour, but the previous tests could fail because of external package metadata or network timeouts. The new assertions keep the same intent while making the suite deterministic and stable.

#### Before

https://github.com/user-attachments/assets/d0ebfbfb-af79-4f09-a385-dc0de20e42aa

#### After

https://github.com/user-attachments/assets/e9825261-1f06-4b8e-92b5-a3a37724c662