### PR TITLE
perf: reduce interactive flicker

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -1,12 +1,11 @@
 import type { CheckOptions, InteractiveContext, PackageMeta, ResolvedDepChange } from '../../types'
 /* eslint-disable no-fallthrough */
 import process from 'node:process'
-/* eslint-disable no-console */
 import readline from 'node:readline'
 import { createControlledPromise, notNullish } from '@antfu/utils'
 import c from 'ansis'
 import { getVersionOfRange, getVersionOfTag, updateTargetVersion } from '../../io/resolves'
-import { colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable } from '../../render'
+import { clearInteractiveScreen, colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable, writeInteractiveScreen } from '../../render'
 import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
 import { getPrefixedVersion } from '../../utils/versions'
@@ -90,7 +89,6 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
           sr.push(...renderChanges(pkg, options, ctx).lines.map(x => ({ content: x })))
         })
 
-        console.clear()
         sr.render(index)
       },
       onKey(key) {
@@ -100,7 +98,7 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
             process.exit()
           case 'enter':
           case 'return':
-            console.clear()
+            clearInteractiveScreen()
             pkgs.forEach((pkg) => {
               pkg.resolved.forEach((dep) => {
                 dep.update = ctx.isChecked(dep)
@@ -170,21 +168,19 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
 
     return {
       render() {
-        console.clear()
-        console.log(`${FIG_BLOCK} ${c.gray`Select a version for ${c.green.bold(dep.name)}${c.gray` (current ${dep.currentVersion})`}`}`)
-        console.log()
-        console.log(
-          formatTable(versions.map((v, idx) => {
-            return [
-              (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
-              timediff ? timeDifference(dep.currentVersionTime) : '',
-              c.gray(dep.currentVersion),
-              c.dim.gray('→'),
-              colorizeVersionDiff(dep.currentVersion, v.targetVersion),
-              timediff ? timeDifference(v.time) : '',
-            ]
-          }), 'LLLL').join('\n'),
-        )
+        const headerLine = `${FIG_BLOCK} ${c.gray`Select a version for ${c.green.bold(dep.name)}${c.gray` (current ${dep.currentVersion})`}`}`
+        const versionLines = formatTable(versions.map((v, idx) => {
+          return [
+            (index === idx ? FIG_POINTER : FIG_NO_POINTER) + (index === idx ? v.name : c.gray(v.name)),
+            timediff ? timeDifference(dep.currentVersionTime) : '',
+            c.gray(dep.currentVersion),
+            c.dim.gray('→'),
+            colorizeVersionDiff(dep.currentVersion, v.targetVersion),
+            timediff ? timeDifference(v.time) : '',
+          ]
+        }), 'LLLL').join('\n')
+
+        writeInteractiveScreen([headerLine, '', versionLines])
       },
       onKey(key) {
         switch (key.name) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import process from 'node:process'
+import readline from 'node:readline'
 import { stripVTControlCharacters } from 'node:util'
 import c from 'ansis'
 import { SemVer } from 'semver-es'
@@ -111,6 +112,27 @@ export function colorizeVersionDiff(from: string, to: string, hightlightRange = 
     + c[color](partsToColor.slice(i).join('.')).trim()
 }
 
+export function clearInteractiveScreen() {
+  if (process.stdout.isTTY) {
+    readline.cursorTo(process.stdout, 0, 0)
+    readline.clearScreenDown(process.stdout)
+
+    return
+  }
+
+  console.clear()
+}
+
+export function writeInteractiveScreen(lines: string[]) {
+  clearInteractiveScreen()
+
+  const output = lines.join('\n')
+  if (output === '')
+    return
+
+  process.stdout.write(`${output}\n`)
+}
+
 interface SliceRenderLine {
   content: string
   fixed?: boolean
@@ -128,6 +150,7 @@ export function createSliceRender() {
         rows: remainHeight,
         columns: availableWidth,
       } = process.stdout
+      const outputLines: string[] = []
 
       const lines: SliceRenderLine[] = buffer.length < remainHeight - 1
         ? buffer
@@ -139,7 +162,7 @@ export function createSliceRender() {
       while (i < lines.length) {
         const curr = lines[i]
         if (curr.fixed) {
-          console.log(curr.content)
+          outputLines.push(curr.content)
           remainHeight -= 1
           i++
         }
@@ -180,7 +203,9 @@ export function createSliceRender() {
         slice = remainLines.slice(start, start + remainHeight)
       }
 
-      console.log(slice.map(x => x.content).join('\n'))
+      outputLines.push(...slice.map(line => line.content))
+
+      writeInteractiveScreen(outputLines)
     },
   }
 }

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,5 +1,21 @@
-import { expect, it } from 'vitest'
-import { formatTable } from '../src/render'
+import process from 'node:process'
+import readline from 'node:readline'
+import { afterEach, expect, it, vi } from 'vitest'
+import { formatTable, writeInteractiveScreen } from '../src/render'
+
+const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  if (originalIsTTYDescriptor) {
+    Object.defineProperty(process.stdout, 'isTTY', originalIsTTYDescriptor)
+
+    return
+  }
+
+  Reflect.deleteProperty(process.stdout, 'isTTY')
+})
 
 it('formatTable', () => {
   expect(
@@ -13,4 +29,18 @@ it('formatTable', () => {
       "hello     hi  foobar",
     ]
   `)
+})
+
+it('writeInteractiveScreen uses cursor-based redraw for tty output', () => {
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+
+  const cursorToSpy = vi.spyOn(readline, 'cursorTo').mockImplementation(() => true)
+  const clearScreenDownSpy = vi.spyOn(readline, 'clearScreenDown').mockImplementation(() => true)
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+  writeInteractiveScreen(['first line', 'second line'])
+
+  expect(cursorToSpy).toHaveBeenCalledWith(process.stdout, 0, 0)
+  expect(clearScreenDownSpy).toHaveBeenCalledWith(process.stdout)
+  expect(writeSpy).toHaveBeenCalledWith('first line\nsecond line\n')
 })


### PR DESCRIPTION
### 🧭 Context

The interactive check flow redraws the screen frequently while navigating dependency and version selection views.

This change reduces visible flicker by switching the redraw path to cursor-based terminal updates instead of relying on broader screen-clearing behaviour.

### 📚 Description

The interactive renderer now updates the terminal using cursor-positioned redraws so repeated navigation feels steadier and less noisy. The main goal is to reduce the visible flicker that happens during fast interactive updates.

#### Before

https://github.com/user-attachments/assets/b46f5a42-beaf-4810-9bcd-ae1896c2161a

#### After

https://github.com/user-attachments/assets/1d408a7e-a5cb-459e-a0ae-9e62f52ef12e