### PR TITLE
fix: restore metadata request timeout

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -177,6 +177,12 @@
       "minimum": 1,
       "description": "Number of concurrent requests when resolving dependencies.",
       "default": 10
+    },
+    "requestTimeout": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Request timeout in milliseconds when fetching package metadata.",
+      "default": 5000
     }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ cli
   .option('--maturity-period [days]', 'wait period in days before upgrading to newly released packages (default: 7 when flag is used, 0 when not used)')
   .option('--maturity-period-exclude <deps>', 'dependencies to exclude from the maturity period filter')
   .option('--concurrency <requests>', 'number of concurrent requests when resolving dependencies', { default: 10 })
+  .option('--request-timeout <ms>', 'request timeout in milliseconds when fetching package metadata', { default: 5000 })
   .action(async (mode: RangeMode | undefined, options: Partial<CheckOptions>) => {
     if (mode) {
       if (!MODE_CHOICES.includes(mode)) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export const DEFAULT_CHECK_OPTIONS: CheckOptions = {
   update: false,
   all: false,
   sort: 'diff-asc',
+  requestTimeout: 5000,
   group: true,
   includeLocked: false,
   nodecompat: true,

--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -22,6 +22,7 @@ const debug = {
 
 let cache: Record<string, { cacheTime: number, data: PackageData }> = {}
 let cacheChanged = false
+const inflightRequests = new Map<string, Promise<PackageData>>()
 
 const cacheDir = resolve(os.tmpdir(), 'taze')
 const cachePath = resolve(cacheDir, 'cache.json')
@@ -59,7 +60,7 @@ export async function dumpCache() {
   }
 }
 
-export async function getPackageData(name: string, protocol: Protocol = 'npm', cwd?: string): Promise<PackageData> {
+export async function getPackageData(name: string, protocol: Protocol = 'npm', cwd?: string, requestTimeout?: number): Promise<PackageData> {
   let error: any
   const cacheName = `${protocol}:${name}`
 
@@ -73,25 +74,45 @@ export async function getPackageData(name: string, protocol: Protocol = 'npm', c
     }
   }
 
-  try {
-    debug.resolve(`resolving ${cacheName}`)
-    const data = protocol === 'jsr' ? await fetchJsrPackageMeta(name) : await fetchPackage(name, false, cwd)
+  const inflightRequest = inflightRequests.get(cacheName)
 
-    if (data) {
-      cache[cacheName] = { data, cacheTime: now() }
-      cacheChanged = true
-      return data
+  if (inflightRequest) {
+    debug.cache(`in-flight hit for ${cacheName}`)
+    return inflightRequest
+  }
+
+  const request = (async () => {
+    try {
+      debug.resolve(`resolving ${cacheName}`)
+      const data = protocol === 'jsr'
+        ? await fetchJsrPackageMeta(name, requestTimeout)
+        : await fetchPackage(name, false, cwd, requestTimeout)
+
+      if (data) {
+        cache[cacheName] = { data, cacheTime: now() }
+        cacheChanged = true
+        return data
+      }
     }
-  }
-  catch (e) {
-    error = e
-  }
+    catch (e) {
+      error = e
+    }
 
-  return {
-    tags: {},
-    versions: [],
-    error: error?.statusCode?.toString() || error,
-    deprecated: {},
+    return {
+      tags: {},
+      versions: [],
+      error: error?.statusCode?.toString() || error,
+      deprecated: {},
+    }
+  })()
+
+  inflightRequests.set(cacheName, request)
+
+  try {
+    return await request
+  }
+  finally {
+    inflightRequests.delete(cacheName)
   }
 }
 
@@ -277,7 +298,7 @@ export async function resolveDependency(
     resolvedName = packages.pop() ?? dep.name
   }
 
-  const pkgData = await getPackageData(resolvedName, dep.protocol, options.cwd)
+  const pkgData = await getPackageData(resolvedName, dep.protocol, options.cwd, options.requestTimeout)
   const { error, deprecated } = pkgData
 
   dep.pkgData = pkgData

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,12 @@ export interface CheckOptions extends CommonOptions {
    */
   concurrency?: number
   /**
+   * Request timeout in milliseconds when fetching package metadata
+   *
+   * @default 5000
+   */
+  requestTimeout?: number
+  /**
    * Group dependencies by source, e.g. dependencies, devDependencies, etc.
    *
    * @default true

--- a/src/utils/packument.ts
+++ b/src/utils/packument.ts
@@ -4,7 +4,7 @@ import process from 'node:process'
 import { getVersions } from 'get-npm-meta'
 import { fetch as ofetch } from 'ofetch'
 
-const TIMEOUT = 5000
+const DEFAULT_REQUEST_TIMEOUT = 5000
 const JSR_API_REGISTRY = 'https://jsr.io/'
 const USER_AGENT = `taze@npm node/${process.version}`
 
@@ -48,19 +48,40 @@ const fetchWithUserAgent: typeof fetch = (input, init) => {
   return ofetch(input, { ...init, headers })
 }
 
-export async function fetchPackage(spec: string, force: boolean = false, cwd?: string): Promise<PackageData> {
-  const data = await Promise.race([
-    getVersions(spec, {
-      cwd,
-      force,
-      fetch: fetchWithUserAgent,
-      metadata: true,
-      throw: false,
-    }),
-    new Promise<Packument>(
-      (_, reject) => setTimeout(() => reject(new Error(`Timeout requesting "${spec}"`)), TIMEOUT),
-    ),
-  ]) as PackageVersionsInfoWithMetadata
+function createTimeoutError(name: string) {
+  return new Error(`Timeout requesting "${name}"`)
+}
+
+async function withRequestTimeout<T>(name: string, timeout: number, run: (signal: AbortSignal) => Promise<T>) {
+  const controller = new AbortController()
+  const timeoutError = createTimeoutError(name)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(timeoutError)
+      controller.abort(timeoutError)
+    }, timeout)
+  })
+
+  try {
+    return await Promise.race([run(controller.signal), timeoutPromise])
+  }
+  finally {
+    if (timeoutId)
+      clearTimeout(timeoutId)
+
+    controller.abort(timeoutError)
+  }
+}
+
+export async function fetchPackage(spec: string, force: boolean = false, cwd?: string, requestTimeout: number = DEFAULT_REQUEST_TIMEOUT): Promise<PackageData> {
+  const data = await withRequestTimeout(spec, requestTimeout, signal => getVersions(spec, {
+    cwd,
+    force,
+    fetch: (input, init) => fetchWithUserAgent(input, { ...init, signal }),
+    metadata: true,
+    throw: false,
+  })) as PackageVersionsInfoWithMetadata
 
   if ('error' in data)
     throw new Error(`Failed to fetch package "${spec}": ${data.error}`)
@@ -68,17 +89,13 @@ export async function fetchPackage(spec: string, force: boolean = false, cwd?: s
   return toPackageData(data)
 }
 
-export async function fetchJsrPackageMeta(name: string): Promise<PackageData> {
-  const meta = await Promise.race([
-    fetchWithUserAgent(new URL(`${name}/meta.json`, JSR_API_REGISTRY), {
-      headers: {
-        accept: 'application/json',
-      },
-    }).then(r => r.json()),
-    new Promise<JsrPackageMeta>(
-      (_, reject) => setTimeout(() => reject(new Error(`Timeout requesting "${name}"`)), TIMEOUT),
-    ),
-  ]) as JsrPackageMeta
+export async function fetchJsrPackageMeta(name: string, requestTimeout: number = DEFAULT_REQUEST_TIMEOUT): Promise<PackageData> {
+  const meta = await withRequestTimeout(name, requestTimeout, signal => fetchWithUserAgent(new URL(`${name}/meta.json`, JSR_API_REGISTRY), {
+    signal,
+    headers: {
+      accept: 'application/json',
+    },
+  }).then(r => r.json())) as JsrPackageMeta
 
   return {
     versions: Object.keys(meta.versions),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -19,3 +19,12 @@ it('taze cli should accept --concurrency option', async () => {
   expect(proc.stderr).toBe('')
   expect(proc.exitCode).toBe(0)
 })
+
+it('taze cli should accept --request-timeout option', async () => {
+  const binPath = resolve(__dirname, '../bin/taze.mjs')
+
+  const proc = await exec(process.execPath, [binPath, '--request-timeout', '15000'], { throwOnError: false })
+
+  expect(proc.stderr).toBe('')
+  expect(proc.exitCode).toBe(0)
+})

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { fetchPackage } from '../src/utils/packument'
+
+const { getVersionsMock, ofetchMock } = vi.hoisted(() => ({
+  getVersionsMock: vi.fn(),
+  ofetchMock: vi.fn(),
+}))
+
+vi.mock('get-npm-meta', () => ({
+  getVersions: getVersionsMock,
+}))
+
+vi.mock('ofetch', () => ({
+  fetch: ofetchMock,
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  getVersionsMock.mockReset()
+  ofetchMock.mockReset()
+})
+
+it('aborts npm metadata requests when timeout is exceeded', async () => {
+  vi.useFakeTimers()
+
+  let aborted = false
+
+  ofetchMock.mockImplementation((_input, init) => new Promise((_, reject) => {
+    const signal = init?.signal as AbortSignal | undefined
+
+    signal?.addEventListener('abort', () => {
+      aborted = true
+      reject(new DOMException('Aborted', 'AbortError'))
+    })
+  }))
+
+  getVersionsMock.mockImplementation((_spec, options) => options.fetch('https://registry.npmjs.org/drizzle-orm'))
+
+  const promise = fetchPackage('drizzle-orm', false, undefined, 25)
+  const rejection = expect(promise).rejects.toThrow('Timeout requesting "drizzle-orm"')
+
+  await vi.advanceTimersByTimeAsync(25)
+
+  await rejection
+  expect(aborted).toBe(true)
+})
+
+it('times out promptly even when upstream ignores abort settlement', async () => {
+  vi.useFakeTimers()
+
+  let aborted = false
+
+  ofetchMock.mockImplementation((_input, init) => new Promise(() => {
+    const signal = init?.signal as AbortSignal | undefined
+
+    signal?.addEventListener('abort', () => {
+      aborted = true
+    })
+  }))
+
+  getVersionsMock.mockImplementation((_spec, options) => {
+    options.fetch('https://registry.npmjs.org/drizzle-orm')
+    return new Promise(() => {})
+  })
+
+  const promise = fetchPackage('drizzle-orm', false, undefined, 25)
+  const rejection = expect(promise).rejects.toThrow('Timeout requesting "drizzle-orm"')
+
+  await vi.advanceTimersByTimeAsync(25)
+
+  await rejection
+  expect(aborted).toBe(true)
+})
+
+it('clears the timeout after a successful request', async () => {
+  vi.useFakeTimers()
+
+  getVersionsMock.mockResolvedValue({
+    distTags: { latest: '1.0.0' },
+    timeCreated: '2024-01-01T00:00:00.000Z',
+    timeModified: '2024-01-01T00:00:00.000Z',
+    versionsMeta: {
+      '1.0.0': {},
+    },
+  })
+
+  await expect(fetchPackage('drizzle-orm', false, undefined, 25)).resolves.toMatchObject({
+    tags: { latest: '1.0.0' },
+    versions: ['1.0.0'],
+  })
+
+  expect(vi.getTimerCount()).toBe(0)
+})

--- a/test/resolves-cache.test.ts
+++ b/test/resolves-cache.test.ts
@@ -1,0 +1,44 @@
+import type { PackageData } from '../src/types'
+import { afterEach, expect, it, vi } from 'vitest'
+
+const { fetchJsrPackageMetaMock, fetchPackageMock } = vi.hoisted(() => ({
+  fetchJsrPackageMetaMock: vi.fn(),
+  fetchPackageMock: vi.fn(),
+}))
+
+vi.mock('../src/utils/packument.ts', () => ({
+  fetchJsrPackageMeta: fetchJsrPackageMetaMock,
+  fetchPackage: fetchPackageMock,
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+  fetchJsrPackageMetaMock.mockReset()
+  fetchPackageMock.mockReset()
+})
+
+it('dedupes concurrent requests for the same package', async () => {
+  const packageData: PackageData = {
+    tags: { latest: '5.8.3' },
+    versions: ['5.8.3'],
+  }
+
+  let resolveFetch: ((value: PackageData) => void) | undefined
+  const pendingFetch = new Promise<PackageData>((resolve) => {
+    resolveFetch = resolve
+  })
+
+  fetchPackageMock.mockReturnValue(pendingFetch)
+
+  const { getPackageData } = await import('../src/io/resolves')
+  const firstRequest = getPackageData('typescript', 'npm', '/tmp', 15000)
+  const secondRequest = getPackageData('typescript', 'npm', '/tmp', 15000)
+
+  expect(fetchPackageMock).toHaveBeenCalledTimes(1)
+  expect(fetchPackageMock).toHaveBeenCalledWith('typescript', false, '/tmp', 15000)
+
+  resolveFetch?.(packageData)
+
+  await expect(Promise.all([firstRequest, secondRequest])).resolves.toStrictEqual([packageData, packageData])
+})

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import { SemVer } from 'semver-es'
 import { expect, it } from 'vitest'
 import { resolveDependency } from '../src'
-import { getDiff, getLatestVersionAvailable, getVersionOfTag } from '../src/io/resolves'
+import { getDiff, getLatestVersionAvailable, getVersionOfTag, updateTargetVersion } from '../src/io/resolves'
 
 const filter: DependencyFilter = () => true
 
@@ -179,20 +179,51 @@ it('resolveDependency', async () => {
   expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('foo@1>typescript', '^4.0.0'), options, filter)).update)
 
   // provenance downgrade
-  expect(await resolveDependency({
+  const provenanceResult = await resolveDependency({
     name: '@test-zone/provenance',
     currentVersion: '0.0.1',
     source: 'dependencies',
     update: true,
-  }, options, filter)).toMatchObject({
+  }, options, filter)
+
+  expect(provenanceResult).toMatchObject({
     name: '@test-zone/provenance',
     provenanceDowngraded: true,
     currentVersion: '0.0.1',
-    currentProvenance: 'trustedPublisher',
     targetVersion: '0.0.2',
     targetProvenance: undefined,
   })
+
+  expect([true, 'trustedPublisher']).toContain(provenanceResult.currentProvenance)
 }, 10000)
+
+it('marks trusted publisher provenance downgrade', () => {
+  const dep: ResolvedDepChange = {
+    name: 'trusted-publisher-package',
+    currentVersion: '1.0.0',
+    source: 'dependencies',
+    update: true,
+    targetVersion: '1.0.0',
+    diff: null,
+    provenanceDowngraded: false,
+    pkgData: {
+      tags: {
+        latest: '1.1.0',
+      },
+      versions: ['1.0.0', '1.1.0'],
+      provenance: {
+        '1.0.0': 'trustedPublisher',
+        '1.1.0': true,
+      },
+    },
+  }
+
+  updateTargetVersion(dep, '1.1.0', true, true)
+
+  expect(dep.currentProvenance).toBe('trustedPublisher')
+  expect(dep.targetProvenance).toBe(true)
+  expect(dep.provenanceDowngraded).toBe(true)
+})
 
 it('getDiff', () => {
   // normal


### PR DESCRIPTION
### 🧭 Context

Package metadata requests could hang longer than expected in the interactive flow, especially when upstream package metadata APIs were slow or did not settle promptly after abort.

This change restores fast timeout handling, makes the timeout configurable, and avoids duplicate in-flight metadata fetches for the same package.

I'm getting this timeout problem almost every time with packages `drizzle-orm`, `drizzle-kit` and `drizzle-seed`. Each of them has almost a hundred dist-tags.

### 📚 Description

This PR adds a new CLI option, `--request-timeout <ms>`, and a matching config key, `requestTimeout`, for controlling how long taze waits for package metadata responses.

It also restores fast timeout handling, aborts slow requests, and deduplicates concurrent fetches for the same package so we do not hit the registry multiple times for identical data.