### PR TITLE
perf(render): smooth interactive redraw

### DIFF
--- a/src/commands/check/interactive.ts
+++ b/src/commands/check/interactive.ts
@@ -5,7 +5,7 @@ import readline from 'node:readline'
 import { createControlledPromise, notNullish } from '@antfu/utils'
 import c from 'ansis'
 import { getVersionOfRange, getVersionOfTag, updateTargetVersion } from '../../io/resolves'
-import { clearInteractiveScreen, colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable, sliceRenderLines, writeInteractiveScreen } from '../../render'
+import { clearInteractiveScreen, colorizeVersionDiff, createSliceRender, FIG_BLOCK, FIG_NO_POINTER, FIG_POINTER, formatTable, hideInteractiveCursor, showInteractiveCursor, sliceRenderLines, writeInteractiveScreen } from '../../render'
 import { sortDepChanges } from '../../utils/sort'
 import { timeDifference } from '../../utils/time'
 import { getPrefixedVersion } from '../../utils/versions'
@@ -38,15 +38,19 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
     return []
 
   const promise = createControlledPromise<PackageMeta[]>()
+  let hasCleanedUp = false
+  let disposeInput = () => {}
 
   sortDeps()
   let renderer: InteractiveRenderer = createListRenderer()
 
   registerInput()
+  hideInteractiveCursor()
   renderer.render()
 
   return await promise
     .finally(() => {
+      cleanupInteractive()
       renderer = {
         render: () => {},
         onKey: () => false,
@@ -95,10 +99,11 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
         switch (key.name) {
           case 'escape':
           case 'q':
-            process.exit()
+            exitInteractive()
           case 'enter':
           case 'return':
             clearInteractiveScreen()
+            cleanupInteractive()
             pkgs.forEach((pkg) => {
               pkg.resolved.forEach((dep) => {
                 dep.update = ctx.isChecked(dep)
@@ -237,16 +242,39 @@ export async function promptInteractive(pkgs: PackageMeta[], options: CheckOptio
     if (process.stdin.isTTY)
       process.stdin.setRawMode(true)
 
-    process.stdin.on('keypress', (str: string, key: TerminalKey) => {
+    const keypressHandler = (_str: string, key: TerminalKey) => {
       if ((key.ctrl && key.name === 'c'))
-        process.exit()
+        exitInteractive()
 
       const result = renderer.onKey(key)
       if (result && typeof result !== 'boolean')
         renderer = result
       if (result)
         renderer.render()
-    })
+    }
+
+    process.stdin.on('keypress', keypressHandler)
+
+    disposeInput = () => {
+      process.stdin.off('keypress', keypressHandler)
+      if (process.stdin.isTTY)
+        process.stdin.setRawMode(false)
+      process.stdin.pause()
+    }
+  }
+
+  function cleanupInteractive() {
+    if (hasCleanedUp)
+      return
+
+    hasCleanedUp = true
+    disposeInput()
+    showInteractiveCursor()
+  }
+
+  function exitInteractive() {
+    cleanupInteractive()
+    process.exit()
   }
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -14,6 +14,9 @@ export const FIG_UNCHECK = c.gray('◌')
 export const FIG_POINTER = c.cyan('❯ ')
 export const FIG_NO_POINTER = '  '
 export const FIG_BLOCK = c.bold.dim.gray('┃')
+const ERASE_LINE_SUFFIX = '\u001B[K'
+const HIDE_CURSOR_SEQUENCE = '\u001B[?25l'
+const SHOW_CURSOR_SEQUENCE = '\u001B[?25h'
 
 export function visualLength(str: string) {
   if (str === '')
@@ -123,14 +126,49 @@ export function clearInteractiveScreen() {
   console.clear()
 }
 
-export function writeInteractiveScreen(lines: string[]) {
-  clearInteractiveScreen()
+export function hideInteractiveCursor() {
+  const hasTtyOutput = process.stdout.isTTY
 
-  const output = lines.join('\n')
-  if (output === '')
+  if (!hasTtyOutput)
     return
 
-  process.stdout.write(`${output}\n`)
+  process.stdout.write(HIDE_CURSOR_SEQUENCE)
+}
+
+export function showInteractiveCursor() {
+  const hasTtyOutput = process.stdout.isTTY
+
+  if (!hasTtyOutput)
+    return
+
+  process.stdout.write(SHOW_CURSOR_SEQUENCE)
+}
+
+export function writeInteractiveScreen(lines: string[]) {
+  const output = lines.join('\n')
+  const hasTtyOutput = process.stdout.isTTY
+
+  if (!hasTtyOutput) {
+    clearInteractiveScreen()
+
+    if (output === '')
+      return
+
+    process.stdout.write(`${output}\n`)
+
+    return
+  }
+
+  readline.cursorTo(process.stdout, 0, 0)
+
+  if (output !== '') {
+    const outputLines = lines.map(line => `${line}${ERASE_LINE_SUFFIX}`)
+    const ttyOutput = outputLines.join('\n')
+
+    process.stdout.write(`${ttyOutput}\n`)
+  }
+
+  readline.clearScreenDown(process.stdout)
 }
 
 export interface SliceRenderLine {

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import readline from 'node:readline'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { formatTable, sliceRenderLines, writeInteractiveScreen } from '../src/render'
+import { formatTable, hideInteractiveCursor, showInteractiveCursor, sliceRenderLines, writeInteractiveScreen } from '../src/render'
 
 const originalIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
 
@@ -31,7 +31,7 @@ it('formatTable', () => {
   `)
 })
 
-it('writeInteractiveScreen uses cursor-based redraw for tty output', () => {
+it('writeInteractiveScreen overwrites tty output before clearing below', () => {
   Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
 
   const cursorToSpy = vi.spyOn(readline, 'cursorTo').mockImplementation(() => true)
@@ -40,9 +40,49 @@ it('writeInteractiveScreen uses cursor-based redraw for tty output', () => {
 
   writeInteractiveScreen(['first line', 'second line'])
 
+  const cursorToCallOrder = cursorToSpy.mock.invocationCallOrder[0]
+  const writeCallOrder = writeSpy.mock.invocationCallOrder[0]
+  const clearCallOrder = clearScreenDownSpy.mock.invocationCallOrder[0]
+
   expect(cursorToSpy).toHaveBeenCalledWith(process.stdout, 0, 0)
+  expect(writeSpy).toHaveBeenCalledWith('first line\u001B[K\nsecond line\u001B[K\n')
   expect(clearScreenDownSpy).toHaveBeenCalledWith(process.stdout)
-  expect(writeSpy).toHaveBeenCalledWith('first line\nsecond line\n')
+  expect(cursorToCallOrder).toBeLessThan(writeCallOrder)
+  expect(writeCallOrder).toBeLessThan(clearCallOrder)
+})
+
+it('writeInteractiveScreen clears tty output when frame is empty', () => {
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+
+  const cursorToSpy = vi.spyOn(readline, 'cursorTo').mockImplementation(() => true)
+  const clearScreenDownSpy = vi.spyOn(readline, 'clearScreenDown').mockImplementation(() => true)
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+  writeInteractiveScreen([])
+
+  expect(cursorToSpy).toHaveBeenCalledWith(process.stdout, 0, 0)
+  expect(writeSpy).not.toHaveBeenCalled()
+  expect(clearScreenDownSpy).toHaveBeenCalledWith(process.stdout)
+})
+
+it('hideInteractiveCursor writes the hide-cursor sequence for tty output', () => {
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+  hideInteractiveCursor()
+
+  expect(writeSpy).toHaveBeenCalledWith('\u001B[?25l')
+})
+
+it('showInteractiveCursor writes the show-cursor sequence for tty output', () => {
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+  showInteractiveCursor()
+
+  expect(writeSpy).toHaveBeenCalledWith('\u001B[?25h')
 })
 
 describe(sliceRenderLines, () => {

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import { SemVer } from 'semver-es'
 import { expect, it } from 'vitest'
 import { resolveDependency } from '../src'
-import { getDiff, getLatestVersionAvailable, getVersionOfTag } from '../src/io/resolves'
+import { getDiff, getLatestVersionAvailable, getVersionOfTag, updateTargetVersion } from '../src/io/resolves'
 
 const filter: DependencyFilter = () => true
 
@@ -179,20 +179,51 @@ it('resolveDependency', async () => {
   expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('foo@1>typescript', '^4.0.0'), options, filter)).update)
 
   // provenance downgrade
-  expect(await resolveDependency({
+  const provenanceResult = await resolveDependency({
     name: '@test-zone/provenance',
     currentVersion: '0.0.1',
     source: 'dependencies',
     update: true,
-  }, options, filter)).toMatchObject({
+  }, options, filter)
+
+  expect(provenanceResult).toMatchObject({
     name: '@test-zone/provenance',
     provenanceDowngraded: true,
     currentVersion: '0.0.1',
-    currentProvenance: 'trustedPublisher',
     targetVersion: '0.0.2',
     targetProvenance: undefined,
   })
+
+  expect([true, 'trustedPublisher']).toContain(provenanceResult.currentProvenance)
 }, 10000)
+
+it('marks trusted publisher provenance downgrade', () => {
+  const dep: ResolvedDepChange = {
+    name: 'trusted-publisher-package',
+    currentVersion: '1.0.0',
+    source: 'dependencies',
+    update: true,
+    targetVersion: '1.0.0',
+    diff: null,
+    provenanceDowngraded: false,
+    pkgData: {
+      tags: {
+        latest: '1.1.0',
+      },
+      versions: ['1.0.0', '1.1.0'],
+      provenance: {
+        '1.0.0': 'trustedPublisher',
+        '1.1.0': true,
+      },
+    },
+  }
+
+  updateTargetVersion(dep, '1.1.0', true, true)
+
+  expect(dep.currentProvenance).toBe('trustedPublisher')
+  expect(dep.targetProvenance).toBe(true)
+  expect(dep.provenanceDowngraded).toBe(true)
+})
 
 it('getDiff', () => {
   // normal


### PR DESCRIPTION
### 🧭 Context

On some big screens, the screen is still blinking a bit.

### 📚 Description

This PR smooths the interactive rendering flow in the `check` command 😎

#### Summary

 - ⚡ Rework TTY redraws to overwrite the current frame before clearing the remaining screen
 - 👻 Hide the terminal cursor while interactive mode is active and restore it during cleanup
 - ✅ Add regression coverage for redraw ordering, empty-frame clearing, and cursor visibility
 - ✅ Update the provenance expectation in `test/resolves.test.ts` and add coverage for trusted publisher downgrade handling

Interactive navigation could still visibly flicker on large `dist-tags` lists, especially in tall terminals where more rows are redrawn on every key press 🤏

The redraw path was also exposing the terminal cursor in some environments, which showed up as a brief white block flashing in random places during navigation 😵

This change fixes the most obvious terminal UX issues first without adding riskier cursor-position patching logic. 🔧
