### PR TITLE
fix: respect disabled pnpm release age by `minimumReleaseAge: 0`

### DIFF
--- a/src/utils/detectMaturity.ts
+++ b/src/utils/detectMaturity.ts
@@ -113,10 +113,15 @@ export async function detectMaturityConfig(cwd: string): Promise<DetectedMaturit
   const pnpmYamlPath = findUp('pnpm-workspace.yaml', { cwd })
   const pnpmYaml = await readYamlTop(pnpmYamlPath)
   const pnpmExclude = readStringList(pnpmYaml?.minimumReleaseAgeExclude)
-  if (pnpmYaml && typeof pnpmYaml.minimumReleaseAge === 'number' && pnpmYaml.minimumReleaseAge > 0) {
-    const days = pnpmYaml.minimumReleaseAge / 1440
-    debug(`maturityPeriod=${days}d from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m, minimumReleaseAgeExclude=${JSON.stringify(pnpmExclude)})`)
-    return { maturityPeriod: days, maturityPeriodExclude: pnpmExclude }
+  if (pnpmYaml && typeof pnpmYaml.minimumReleaseAge === 'number') {
+    if (pnpmYaml.minimumReleaseAge > 0) {
+      const days = pnpmYaml.minimumReleaseAge / 1440
+      debug(`maturityPeriod=${days}d from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m, minimumReleaseAgeExclude=${JSON.stringify(pnpmExclude)})`)
+      return { maturityPeriod: days, maturityPeriodExclude: pnpmExclude }
+    }
+
+    debug(`maturityPeriod disabled from ${pnpmYamlPath} (minimumReleaseAge=${pnpmYaml.minimumReleaseAge}m, minimumReleaseAgeExclude=${JSON.stringify(pnpmExclude)})`)
+    return { maturityPeriodExclude: pnpmExclude }
   }
 
   // 2. .yarnrc.yml → npmMinimalAgeGate (duration)

--- a/test/maturityDetection.test.ts
+++ b/test/maturityDetection.test.ts
@@ -86,6 +86,12 @@ describe('detectMaturityPeriod', () => {
       expect(await detectMaturityPeriod(cwd)).toBeUndefined()
     })
 
+    it('respects minimumReleaseAge 0 over pnpm@11 default', async () => {
+      write(cwd, 'package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }))
+      write(cwd, 'pnpm-workspace.yaml', 'minimumReleaseAge: 0\n')
+      expect(await detectMaturityPeriod(cwd)).toBeUndefined()
+    })
+
     it('falls through when the yaml exists without the field', async () => {
       write(cwd, 'pnpm-workspace.yaml', 'packages:\n  - "!**/test/**"\n')
       expect(await detectMaturityPeriod(cwd)).toBeUndefined()


### PR DESCRIPTION
### 🧭 Context

pnpm v11 enables `minimumReleaseAge` as 1 day by default, but users can explicitly disable it with `minimumReleaseAge: 0`.

taze already detects pnpm v11 and applies the default maturity period, but it treated `minimumReleaseAge: 0` as if the setting was absent. As a result, taze could be more restrictive than pnpm and skip valid updates that pnpm itself would install.

### 📚 Description

This PR fix the problem above.