### PR TITLE
fix: avoid premature package request timeouts

### DIFF
--- a/src/utils/packument.ts
+++ b/src/utils/packument.ts
@@ -4,7 +4,7 @@ import process from 'node:process'
 import { getVersions } from 'get-npm-meta'
 import { fetch as ofetch } from 'ofetch'
 
-const TIMEOUT = 5000
+const TIMEOUT = 30_000
 const JSR_API_REGISTRY = 'https://jsr.io/'
 const USER_AGENT = `taze@npm node/${process.version}`
 
@@ -49,7 +49,7 @@ const fetchWithUserAgent: typeof fetch = (input, init) => {
 }
 
 export async function fetchPackage(spec: string, force: boolean = false, cwd?: string): Promise<PackageData> {
-  const data = await Promise.race([
+  const data = await withTimeout(
     getVersions(spec, {
       cwd,
       force,
@@ -57,10 +57,8 @@ export async function fetchPackage(spec: string, force: boolean = false, cwd?: s
       metadata: true,
       throw: false,
     }),
-    new Promise<Packument>(
-      (_, reject) => setTimeout(() => reject(new Error(`Timeout requesting "${spec}"`)), TIMEOUT),
-    ),
-  ]) as PackageVersionsInfoWithMetadata
+    `Timeout requesting "${spec}"`,
+  ) as PackageVersionsInfoWithMetadata
 
   if ('error' in data)
     throw new Error(`Failed to fetch package "${spec}": ${data.error}`)
@@ -69,20 +67,34 @@ export async function fetchPackage(spec: string, force: boolean = false, cwd?: s
 }
 
 export async function fetchJsrPackageMeta(name: string): Promise<PackageData> {
-  const meta = await Promise.race([
+  const meta = await withTimeout(
     fetchWithUserAgent(new URL(`${name}/meta.json`, JSR_API_REGISTRY), {
       headers: {
         accept: 'application/json',
       },
     }).then(r => r.json()),
-    new Promise<JsrPackageMeta>(
-      (_, reject) => setTimeout(() => reject(new Error(`Timeout requesting "${name}"`)), TIMEOUT),
-    ),
-  ]) as JsrPackageMeta
+    `Timeout requesting "${name}"`,
+  ) as JsrPackageMeta
 
   return {
     versions: Object.keys(meta.versions),
     tags: { latest: meta.latest },
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), TIMEOUT)
+      }),
+    ])
+  }
+  finally {
+    clearTimeout(timer)
   }
 }
 

--- a/test/packument.test.ts
+++ b/test/packument.test.ts
@@ -1,0 +1,47 @@
+import type { PackageVersionsInfoWithMetadata } from 'get-npm-meta'
+import { afterEach, expect, it, vi } from 'vitest'
+import { fetchPackage } from '../src/utils/packument'
+
+const { getVersionsMock } = vi.hoisted(() => ({
+  getVersionsMock: vi.fn(),
+}))
+
+vi.mock('get-npm-meta', () => ({
+  getVersions: getVersionsMock,
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+it('allows slow package metadata requests to complete without leaving a timeout pending', async () => {
+  vi.useFakeTimers()
+
+  const packageInfo: PackageVersionsInfoWithMetadata = {
+    name: 'slow-package',
+    distTags: { latest: '1.0.0' },
+    versionsMeta: { '1.0.0': {} },
+    timeCreated: '2026-01-01T00:00:00.000Z',
+    timeModified: '2026-01-01T00:00:00.000Z',
+    lastSynced: Date.now(),
+    specifier: '*',
+  }
+
+  getVersionsMock.mockImplementation(() => new Promise((resolve) => {
+    setTimeout(() => resolve(packageInfo), 10_000)
+  }))
+
+  const result = fetchPackage('slow-package')
+  const assertion = expect(result).resolves.toMatchObject({
+    tags: { latest: '1.0.0' },
+    versions: ['1.0.0'],
+  })
+
+  await Promise.all([
+    assertion,
+    vi.advanceTimersByTimeAsync(10_000),
+  ])
+
+  expect(vi.getTimerCount()).toBe(0)
+})


### PR DESCRIPTION
## Summary

- extend the package metadata request timeout from 5 to 30 seconds
- clear the timeout timer as soon as a request settles
- add regression coverage for successful metadata responses slower than 5 seconds

## Context

Some successful metadata requests take longer than five seconds. Taze currently records those as per-package errors and continues, producing a timeout warning even when the request eventually succeeds.

Closes #230.

## Checks

- build
- typecheck
- lint
- targeted regression test
