### PR TITLE
fix: correctly parse pnpm override compound version range

### DIFF
--- a/src/utils/package.ts
+++ b/src/utils/package.ts
@@ -9,5 +9,5 @@ export function parseYarnPackagePath(input: string): string[] {
  * Parse input string like `package-1>package-2` to an array of packages
  */
 export function parsePnpmPackagePath(input: string): string[] {
-  return input.match(/[^>]+/g) || []
+  return input.match(/(?:>(?=[=\d])|[^>])+/g) || []
 }

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -177,6 +177,7 @@ it('resolveDependency', async () => {
   expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript', 'npm:typescript@^4.0.0'), options, filter)).update)
   expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript@5.0.0', '^4.0.0'), options, filter)).update)
   expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('foo@1>typescript', '^4.0.0'), options, filter)).update)
+  expect(true).toBe((await resolveDependency(makePkgForPnpmOverrides('typescript@>=4.0.0 <5.0.0', '^4.0.0'), options, filter)).update)
 
   // provenance downgrade
   expect(await resolveDependency({


### PR DESCRIPTION
### 🔗 Linked issue

fix #173

### 🧭 Context

<!-- Brief background and why this change is needed -->
`pnpm.overrides` keys can encode two different things: a chain selector (`foo@1>bar`) or a version range on the package itself (`foo@>=1.0.0 <2.0.0`).
`parsePnpmPackagePath` treated every `>` as a chain separator, so a bare `>` inside a compound range (`tar-fs@>=2.0.0 <2.1.2`, produced by pnpm audit --fix) got split incorrectly, and the resolved name ended up being a version fragment instead of the package name - causing `Error: Invalid package name`

<!-- High-level summary of what changed -->
`>` is now only treated as a chain separator when it isn't immediately followed by `=` or a digit, so it no longer matches the `>` inside `>=` or `>1.0.0` ranges

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Changed `parsePnpmPackagePath` in `src/utils/package.ts` to use `(?:>(?=[=\d])|[^>])+` instead of `[^>]+`. Added a test in `test/resolves.test.ts` covering the compound-range case; the existing chain-selector case (`foo@1>typescript`) and single-bound ranges (`esbuild@<=0.24.2`) are unaffected.
Verified manually with the reproduction from the issue via `taze --cwd`.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
