### PR TITLE
fix: handle missing package manager in install hint

### DIFF
--- a/src/commands/check/index.ts
+++ b/src/commands/check/index.ts
@@ -148,7 +148,9 @@ export async function check(options: CheckOptions) {
       const fileTypeName = hasPackageYaml ? 'package.yaml' : 'package.json'
 
       console.log(
-        c.yellow`ℹ changes written to ${fileTypeName}, run ${c.cyan`${packageManager} i`} to install updates.`,
+        packageManager
+          ? c.yellow`ℹ changes written to ${fileTypeName}, run ${c.cyan`${packageManager} i`} to install updates.`
+          : c.yellow`ℹ changes written to ${fileTypeName}, install updates with your preferred package manager.`,
       )
     }
 


### PR DESCRIPTION
## Summary

- avoid rendering `undefined i` after dependency updates are written
- keep the detected package manager command when one is available
- show a generic installation hint when package manager detection returns no result

## Root cause

The install hint interpolated the result of `detect()` unconditionally, even though package manager detection can return `undefined` for projects without package manager metadata or a recognizable lockfile.

## Validation

- `pnpm eslint src/commands/check/index.ts`
- `pnpm typecheck`
- `pnpm build`

---

*This pull request was created with assistance from a code agent.*
