### PR TITLE
test(cli): assert value options in help output

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,29 +2,12 @@ import { resolve } from 'pathe'
 import { exec } from 'tinyexec'
 import { expect, it } from 'vitest'
 
-it('taze cli should just works', async () => {
+it('taze cli should expose options that require values', async () => {
   const binPath = resolve(__dirname, '../bin/taze.mjs')
-
   const proc = await exec(process.execPath, [binPath, '--help'], { throwOnError: false })
 
-  expect(proc.stderr).toBe('')
-  expect(proc.exitCode).toBe(0)
-})
-
-it('taze cli should accept --concurrency option', async () => {
-  const binPath = resolve(__dirname, '../bin/taze.mjs')
-
-  const proc = await exec(process.execPath, [binPath, '--help', '--concurrency', '5'], { throwOnError: false })
-
-  expect(proc.stderr).toBe('')
-  expect(proc.exitCode).toBe(0)
-})
-
-it('taze cli should accept --request-timeout option', async () => {
-  const binPath = resolve(__dirname, '../bin/taze.mjs')
-
-  const proc = await exec(process.execPath, [binPath, '--request-timeout', '15000'], { throwOnError: false })
-
+  expect(proc.stdout).toContain('--concurrency <requests>')
+  expect(proc.stdout).toContain('--request-timeout <ms>')
   expect(proc.stderr).toBe('')
   expect(proc.exitCode).toBe(0)
 })


### PR DESCRIPTION
## Summary

Keep CLI value-option coverage tiny, deterministic, and tied to the generated contract 🚀😎

- ✅ Assert that `--concurrency` requires `<requests>`, preserving the regression guard from #223 🧪
- ✅ Assert that `--request-timeout` requires `<ms>` without running dependency resolution
- 🌐 Replace registry-backed CLI executions with one fast `--help` check, so network speed cannot decide CI 💪

## Motivation

The previous option checks launched the full CLI against the repository, so a parser regression test accidentally depended on live package metadata requests and hit Vitest’s 10-second timeout on Ubuntu 💀. CAC generates help from the same option declarations, so checking the required placeholders catches missing or malformed value options while keeping the test focused and fast 🤙✨.