### PR TITLE
feat: support `devEngines.packageManager` updates

### DIFF
--- a/src/io/packageJson.ts
+++ b/src/io/packageJson.ts
@@ -16,6 +16,37 @@ const allDepsFields = [
   'overrides',
 ] as const satisfies DepType[]
 
+type PackageManagerDeclaration
+  = | { field: 'packageManager', name: string, version: string, hexHash?: string }
+    | { field: 'devEngines', name: string, version: string }
+
+function getPackageManagerDeclaration(raw: Record<string, any>): PackageManagerDeclaration | undefined {
+  if (typeof raw.packageManager === 'string') {
+    const [name, versionWithHash] = raw.packageManager.split('@')
+    if (name && versionWithHash) {
+      // `+` sign can be used to pin the hash of the package manager, we remove it to be semver compatible.
+      const [version, hashPart] = versionWithHash.split('+')
+      if (version) {
+        return {
+          field: 'packageManager',
+          name,
+          version: `^${version}`,
+          hexHash: hashPart?.split('.')[1],
+        }
+      }
+    }
+  }
+
+  const packageManager = raw.devEngines?.packageManager
+  if (typeof packageManager?.name === 'string' && packageManager.name && typeof packageManager.version === 'string' && packageManager.version) {
+    return {
+      field: 'devEngines',
+      name: packageManager.name,
+      version: packageManager.version,
+    }
+  }
+}
+
 function isDepFieldEnabled(key: DepType, options: CommonOptions): boolean {
   if (options.depFields?.[key] === false)
     return false
@@ -39,12 +70,11 @@ export async function loadPackageJSON(
       continue
 
     if (key === 'packageManager') {
-      if (raw.packageManager) {
-        const [name, versionWithHash] = raw.packageManager.split('@')
-        // `+` sign can be used to pin the hash of the package manager, we remove it to be semver compatible.
-        const [version, hashPart] = versionWithHash.split('+')
-        const hexHash = hashPart?.split('.')[1]
-        deps.push(parseDependency({ name, version: `^${version}`, type: 'packageManager', shouldUpdate, hexHash }))
+      const packageManager = getPackageManagerDeclaration(raw)
+      if (packageManager) {
+        const { name, version } = packageManager
+        const hexHash = packageManager.field === 'packageManager' ? packageManager.hexHash : undefined
+        deps.push(parseDependency({ name, version, type: 'packageManager', shouldUpdate, hexHash }))
       }
     }
     else {
@@ -79,25 +109,31 @@ export async function writePackageJSON(
 
     if (key === 'packageManager') {
       const value = Object.entries(dumpDependencies(pkg.resolved, 'packageManager'))[0]
-      if (value) {
+      const declaration = getPackageManagerDeclaration(pkg.raw || {})
+      if (value && declaration) {
         pkg.raw ||= {}
         const [name, versionWithCaret] = value
-        const version = versionWithCaret.replace('^', '')
-        let packageManagerValue = `${name}@${version}`
+        if (declaration.field === 'packageManager') {
+          const version = versionWithCaret.replace('^', '')
+          let packageManagerValue = `${name}@${version}`
 
-        const resolvedDep = pkg.resolved.find(dep => dep.source === 'packageManager' && dep.name === name)
-        if (resolvedDep?.hexHash) {
-          // `pkgData` may be undefined when the dep was filtered out (e.g. via
-          // `--include`) and the resolve path that fetches registry data was
-          // skipped. In that case there's no fresh integrity to refresh with.
-          const integrity = resolvedDep.pkgData?.integrity?.[version]
-          if (integrity) {
-            const newHexHash = getHexHashFromIntegrity(integrity)
-            packageManagerValue = `${packageManagerValue}+sha512.${newHexHash}`
+          const resolvedDep = pkg.resolved.find(dep => dep.source === 'packageManager' && dep.name === name)
+          if (resolvedDep?.hexHash) {
+            // `pkgData` may be undefined when the dep was filtered out (e.g. via
+            // `--include`) and the resolve path that fetches registry data was
+            // skipped. In that case there's no fresh integrity to refresh with.
+            const integrity = resolvedDep.pkgData?.integrity?.[version]
+            if (integrity) {
+              const newHexHash = getHexHashFromIntegrity(integrity)
+              packageManagerValue = `${packageManagerValue}+sha512.${newHexHash}`
+            }
           }
-        }
 
-        pkg.raw.packageManager = packageManagerValue
+          pkg.raw.packageManager = packageManagerValue
+        }
+        else {
+          pkg.raw.devEngines.packageManager.version = versionWithCaret
+        }
         changed = true
       }
     }

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { CheckPackages } from '../src'
-import { writePackageJSON } from '../src/io/packageJson'
+import { loadPackageJSON, writePackageJSON } from '../src/io/packageJson'
 import { getHexHashFromIntegrity } from '../src/utils/sha'
 
 function getPkgInfo(name: string, result: ResolvedDepChange[]) {
@@ -26,6 +26,18 @@ const originalPkgJsonWithSha = {
   name: '@taze/package-manager-sha',
   private: true,
   packageManager: `pnpm@${pnpmVersion}+sha512.${pnpmHexHash}`,
+}
+
+const originalPkgJsonWithDevEngines = {
+  name: '@taze/dev-engines-package-manager',
+  private: true,
+  devEngines: {
+    packageManager: {
+      name: 'pnpm',
+      version: `^${pnpmVersion}`,
+      onFail: 'warn',
+    },
+  },
 }
 
 describe('get hex hash from integrity', () => {
@@ -79,6 +91,43 @@ describe('check package for packageManager', () => {
     expect(updatedPnpmInfo.currentVersion).not.toBe(`^${pnpmVersion}`)
     const pkgJson = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
     expect(pkgJson.packageManager).toBe(`pnpm@${updatedPnpmInfo.currentVersion.slice(1)}`)
+  })
+
+  it('write updated devEngines.packageManager to package.json', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify(originalPkgJsonWithDevEngines, null, 2),
+    )
+    const options: CheckOptions = {
+      cwd: tempDir,
+      mode: 'default',
+      write: true,
+      force: true,
+    }
+    await CheckPackages(options, {})
+    const updatedResult = (await CheckPackages(options, {})).packages[0].resolved
+    const updatedPnpmInfo = getPkgInfo('pnpm', updatedResult)
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
+
+    expect(updatedPnpmInfo.update).toBe(false)
+    expect(pkgJson.packageManager).toBeUndefined()
+    expect(pkgJson.devEngines.packageManager).toEqual({
+      ...originalPkgJsonWithDevEngines.devEngines.packageManager,
+      version: updatedPnpmInfo.currentVersion,
+    })
+  })
+
+  it.each([
+    ['missing name', { devEngines: { packageManager: { version: '^10.0.0' } } }, undefined, undefined],
+    ['missing version', { devEngines: { packageManager: { name: 'pnpm' } } }, undefined, undefined],
+    ['incomplete fallback', { packageManager: 'npm@10.0.0', devEngines: { packageManager: { name: 'pnpm' } } }, 'npm', '^10.0.0'],
+    ['packageManager priority', { packageManager: 'npm@10.0.0', devEngines: { packageManager: { name: 'pnpm', version: '^10.0.0' } } }, 'npm', '^10.0.0'],
+  ])('%s', async (_, raw, name, version) => {
+    const [pkg] = await loadPackageJSON('package.json', {}, () => true, raw)
+    const packageManager = pkg.deps.find(dep => dep.source === 'packageManager')
+
+    expect(packageManager?.name).toBe(name)
+    expect(packageManager?.currentVersion).toBe(version)
   })
 })
 


### PR DESCRIPTION
Enable version updates for `devEngines.packageManager` when no valid top-level `packageManager` declaration is available.

---

*This pull request was created with assistance from a code agent.*
