### PR TITLE
fix: keep locked updates within patch range

### DIFF
--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -353,18 +353,6 @@ export function updateTargetVersion(
     = !!(dep.currentProvenance && !dep.targetProvenance) // trusted -> none, provenance -> none
       || (dep.currentProvenance === 'trustedPublisher' && dep.targetProvenance === true) // trusted -> provenance
 
-  if (versionLocked && isEqual(dep.currentVersion, dep.targetVersion)) {
-    // for example: `taze`/`taze -P` is default mode (and it matched from patch to minor)
-    // - but this mode will always ignore the locked pkgs
-    // - so we need to reset the target
-    const { versions, time = {}, tags } = dep.pkgData
-    const targetVersion = getMaxSatisfying(dep.filteredVersions ?? versions, dep.currentVersion, 'minor', tags)
-    if (targetVersion) {
-      dep.targetVersion = targetVersion
-      dep.targetVersionTime = time[dep.targetVersion]
-    }
-  }
-
   try {
     const current = findMinimumForRange(dep.currentVersion)!
     const target = findMinimumForRange(dep.targetVersion)!

--- a/test/package-manager.test.ts
+++ b/test/package-manager.test.ts
@@ -1,20 +1,42 @@
-import type { CheckOptions, PackageMeta, ResolvedDepChange } from '../src'
+import type { CheckOptions, PackageData, PackageMeta, ResolvedDepChange } from '../src'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CheckPackages } from '../src'
 import { loadPackageJSON, writePackageJSON } from '../src/io/packageJson'
 import { getHexHashFromIntegrity } from '../src/utils/sha'
+
+const { fetchPackageMock } = vi.hoisted(() => ({
+  fetchPackageMock: vi.fn(),
+}))
+
+vi.mock('../src/utils/packument.ts', async importActual => ({
+  ...await importActual<typeof import('../src/utils/packument')>(),
+  fetchPackage: fetchPackageMock,
+}))
 
 function getPkgInfo(name: string, result: ResolvedDepChange[]) {
   return result.filter(r => r.name === name)[0]
 }
 
 const pnpmVersion = '10.23.0'
+const updatedPnpmVersion = '10.24.0'
 const pnpmIntegrity = 'sha512-IcTlaYACrel+Tv6Li0qJqN48haN5GflX56DzDzj7xbvdBZgP/ikXmy+25uaRJC4JjZRdFgF3LK0P71+2QR4qSw=='
+const updatedPnpmIntegrity = 'sha512-dXBkYXRlZC1wbnBtLWludGVncml0eQ=='
 const pnpmHexHash = '21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b'
+
+const pnpmPackageData: PackageData = {
+  tags: { latest: updatedPnpmVersion },
+  versions: [pnpmVersion, updatedPnpmVersion],
+  integrity: {
+    [pnpmVersion]: pnpmIntegrity,
+    [updatedPnpmVersion]: updatedPnpmIntegrity,
+  },
+}
+
+fetchPackageMock.mockResolvedValue(pnpmPackageData)
 
 const originalPkgJson = {
   name: '@taze/package-manager',

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -237,6 +237,23 @@ it('still fully excludes a package when no version is given in `exclude`', () =>
   expect(getVersionOfRange(makeResolvedDepWithMajors(), 'major', excludeOptions)).toBeUndefined()
 })
 
+it('keeps locked dependencies within patch range in patch mode', async () => {
+  const patchOptions = {
+    ...options,
+    mode: 'patch' as const,
+    includeLocked: true,
+  }
+
+  const patchUpdate = await resolveDependency(makePkg('4.0.0'), patchOptions, filter)
+  expect(patchUpdate.targetVersion).toBe('4.0.5')
+  expect(patchUpdate.update).toBe(true)
+
+  const noPatchUpdate = await resolveDependency(makePkg('4.0.5'), patchOptions, filter)
+  expect(noPatchUpdate.targetVersion).toBe('4.0.5')
+  expect(noPatchUpdate.update).toBe(false)
+  expect(noPatchUpdate.latestVersionAvailable).toBe('6.0.0')
+})
+
 it('resolveDependency', async () => {
   // default
   expect(false).toBe((await resolveDependency(makePkg(''), options, filter)).update)


### PR DESCRIPTION
## Summary

Keeps `patch --include-locked` within the requested patch range 🐛

- Remove the fallback from patch to minor updates
- Add regression coverage for locked patch dependencies

## Related issues

Related to #209 and #220.