### PR TITLE
fix: preserve default locked updates

### DIFF
--- a/src/io/resolves.ts
+++ b/src/io/resolves.ts
@@ -469,7 +469,14 @@ export async function resolveDependency(
         return dep
       }
 
-      target = getVersionOfRange(dep, mergeMode as RangeMode, options)
+      const versionLocked = /^\d+/.test(dep.currentVersion)
+      // Bare `--include-locked` historically checks exact versions within the minor range.
+      // Explicit modes and per-package modes must keep their selected range.
+      const targetMode = options.includeLocked && versionLocked && mergeMode === 'default'
+        ? 'minor'
+        : mergeMode
+
+      target = getVersionOfRange(dep, targetMode as RangeMode, options)
 
       if (!target) {
         dep.diff = null

--- a/test/resolves.test.ts
+++ b/test/resolves.test.ts
@@ -254,6 +254,23 @@ it('keeps locked dependencies within patch range in patch mode', async () => {
   expect(noPatchUpdate.latestVersionAvailable).toBe('6.0.0')
 })
 
+it('includes locked dependencies within minor range in default mode', async () => {
+  const defaultOptions = {
+    ...options,
+    mode: 'default' as const,
+    includeLocked: true,
+  }
+
+  const minorUpdate = await resolveDependency(makePkg('4.0.0'), defaultOptions, filter)
+  expect(minorUpdate.targetVersion).toBe('4.9.5')
+  expect(minorUpdate.update).toBe(true)
+
+  const noMinorUpdate = await resolveDependency(makePkg('4.9.5'), defaultOptions, filter)
+  expect(noMinorUpdate.targetVersion).toBe('4.9.5')
+  expect(noMinorUpdate.update).toBe(false)
+  expect(noMinorUpdate.latestVersionAvailable).toBe('6.0.0')
+})
+
 it('resolveDependency', async () => {
   // default
   expect(false).toBe((await resolveDependency(makePkg(''), options, filter)).update)


### PR DESCRIPTION
## Summary

Restores bare `taze --include-locked` updates after the strict patch-range fix 🐛🔒 The default stays safe while explicit modes keep doing exactly what they say 😎👍

- 🐛 Treat exact locked versions as a minor range only when the effective mode is `default`
- 🎯 Keep explicit and per-package modes within their selected ranges
- ✅ Cover default-mode updates and the no-minor-update case with deterministic package metadata

## Motivation

PR #307 correctly stopped explicit patch mode from falling back to minor updates, but removing the shared fallback also left exact dependencies unchanged for bare `taze --include-locked`. This restores the historical safe default without reintroducing patch-to-minor updates 🌬

## Related issues

Follow-up to #307

Related to #209