### PR TITLE
feat: respect DO_NOT_TRACK to disable the third-party metadata endpoint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -144,5 +144,14 @@ export async function resolveConfig(
     }
   }
 
+  // When DO_NOT_TRACK is set, skip the third-party fast-npm-meta endpoint and
+  // use the direct registry client instead. The fast-npm-meta endpoint receives
+  // every dependency name in the project, which is a privacy concern an operator
+  // may not want. DO_NOT_TRACK is an informal convention that many CLI tools
+  // honor: https://donottrack.sh/
+  if (process.env.DO_NOT_TRACK) {
+    checkMerged.fastNpmMetaApiEndpoint = undefined
+  }
+
   return merged
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,7 +2,8 @@ import type { CheckOptions, CommonOptions } from '../src'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import process from 'node:process'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveConfig } from '../src/config'
 
 const tmpRoots: string[] = []
@@ -79,5 +80,45 @@ describe('resolveConfig infers maturity settings', () => {
     const options: CheckOptions = { cwd, loglevel: 'silent', maturityPeriod: 7 }
     const { maturityPeriod } = (await resolveConfig(options)) as CheckOptions
     expect(maturityPeriod).toBe(7)
+  })
+})
+
+describe('resolveConfig honors DO_NOT_TRACK for the fast-npm-meta endpoint', () => {
+  let cwd: string
+
+  beforeEach(() => {
+    cwd = makeTmp()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('clears fastNpmMetaApiEndpoint when DO_NOT_TRACK is set', async () => {
+    vi.stubEnv('DO_NOT_TRACK', '1')
+    const options: CommonOptions = { cwd, fastNpmMetaApiEndpoint: 'https://example.com/meta' }
+    const { fastNpmMetaApiEndpoint } = await resolveConfig(options)
+    expect(fastNpmMetaApiEndpoint).toBeUndefined()
+  })
+
+  it('preserves fastNpmMetaApiEndpoint when DO_NOT_TRACK is unset', async () => {
+    vi.stubEnv('DO_NOT_TRACK', '')
+    const options: CommonOptions = { cwd, fastNpmMetaApiEndpoint: 'https://example.com/meta' }
+    const { fastNpmMetaApiEndpoint } = await resolveConfig(options)
+    expect(fastNpmMetaApiEndpoint).toBe('https://example.com/meta')
+  })
+
+  it('preserves fastNpmMetaApiEndpoint when DO_NOT_TRACK is absent', async () => {
+    delete process.env.DO_NOT_TRACK
+    const options: CommonOptions = { cwd, fastNpmMetaApiEndpoint: 'https://example.com/meta' }
+    const { fastNpmMetaApiEndpoint } = await resolveConfig(options)
+    expect(fastNpmMetaApiEndpoint).toBe('https://example.com/meta')
+  })
+
+  it('does not mutate the input options object', async () => {
+    vi.stubEnv('DO_NOT_TRACK', '1')
+    const options: CommonOptions = { cwd, fastNpmMetaApiEndpoint: 'https://example.com/meta' }
+    await resolveConfig(options)
+    expect(options.fastNpmMetaApiEndpoint).toBe('https://example.com/meta')
   })
 })


### PR DESCRIPTION
Thanks for taze.

`DO_NOT_TRACK` is an informal convention that many CLI tools honor (Homebrew, Deno, Turborepo, Netlify CLI, Astro): the tool checks the `DO_NOT_TRACK` environment variable, and skips sending data to third parties when it is set. The point is that someone can set it once and opt out of every tool that honors it, instead of learning a different variable for each one. https://donottrack.sh/

taze routes npm version lookups through the fast-npm-meta hosted endpoint by default. That endpoint receives every dependency name in the project, which is a privacy concern an operator may not want. This PR makes taze honor `DO_NOT_TRACK`: when it is set, `resolveConfig` clears `fastNpmMetaApiEndpoint` so every lookup uses the direct registry client (the packument endpoint) instead of the fast-npm-meta shortcut.

The check is in `resolveConfig`, not in the resolve hot path, so it runs once rather than per dependency. The CLI option `--fast-npm-meta-api-endpoint` still works when `DO_NOT_TRACK` is not set. When it is set, the endpoint is cleared regardless of the CLI flag or config file. No breaking change — the default behaviour is unchanged.
